### PR TITLE
[Feature/#3] 라우팅 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/styled-components": "^5.1.26",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
     "styled-components": "5.3.10",
     "typescript": "^4.4.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,8 @@
+import { RouterProvider } from 'react-router-dom';
+import { router } from 'pages/Router';
+
 const App: React.FC = () => {
-  return <div>관리자 페이지</div>;
+  return <RouterProvider router={router} fallbackElement={<p>Loading...</p>} />;
 };
 
 export default App;

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -1,0 +1,8 @@
+export const PATH = {
+  shopStatus: 'shopstatus',
+  layout: 'layout',
+  statistics: 'statistics',
+  setting: 'setting',
+  login: 'login',
+  join: 'join',
+} as const;

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,14 @@
+interface AuthGuardProps {
+  children: JSX.Element;
+}
+
+/**
+ * 로그인이 된 상태를 체크하기 위한 컴포넌트
+ */
+export const AuthGuard: React.FC<AuthGuardProps> = ({ children }) => {
+  // if (localStorage.getItem(STORAGE.jwt) === null) {
+  //     return <Navigate to={`/${PATH.login}`} />;
+  //   }
+
+  return children;
+};

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+/**
+ * 컴포넌트
+ */
+export const DashboardLayout: React.FC = () => {
+  return (
+    <div style={{ backgroundColor: 'green' }}>
+      대시보드레이아웃
+      <Outlet />
+    </div>
+  );
+};

--- a/src/components/GuestGuard.tsx
+++ b/src/components/GuestGuard.tsx
@@ -1,0 +1,13 @@
+interface GuestGuardProps {
+  children: JSX.Element | any;
+}
+
+/**
+ * 로그인이 되지 않은 상태를 체크하기 위한 컴포넌트
+ */
+export const GuestGuard: React.FC<GuestGuardProps> = ({ children }) => {
+  //   if (localStorage.getItem(STORAGE.jwt)) {
+  //     return <Navigate to='/' />;
+  //   }
+  return children;
+};

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const JoinPage: React.FC = () => {
+  return <div>JoinPage</div>;
+};

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const LayoutSettingPage: React.FC = () => {
+  return <div>LayoutSettingPage</div>;
+};

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const LoginPage: React.FC = () => {
+  return <div style={{ backgroundColor: 'red' }}>LoginPage</div>;
+};

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -1,0 +1,69 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { PATH } from 'common/utils/constants';
+import { AuthGuard } from 'components/AuthGuard';
+import { DashboardLayout } from 'components/DashboardLayout';
+import { GuestGuard } from 'components/GuestGuard';
+import { JoinPage } from 'pages/JoinPage';
+import { LoginPage } from 'pages/LoginPage';
+
+export const router = createBrowserRouter([
+  {
+    path: `/${PATH.login}`,
+    element: (
+      <GuestGuard>
+        <LoginPage />
+      </GuestGuard>
+    ),
+  },
+  {
+    path: `/${PATH.join}`,
+    element: (
+      <GuestGuard>
+        <JoinPage />
+      </GuestGuard>
+    ),
+  },
+  {
+    path: '/',
+    element: (
+      <AuthGuard>
+        <DashboardLayout />
+      </AuthGuard>
+    ),
+    children: [
+      {
+        index: true,
+        async lazy(): Promise<{ Component: React.FC }> {
+          const { ShopStatusPage } = await import('./ShopStatusPage');
+          return { Component: ShopStatusPage };
+        },
+      },
+      {
+        path: PATH.layout,
+        async lazy(): Promise<{ Component: React.FC }> {
+          const { LayoutSettingPage } = await import('./LayoutSettingPage');
+          return { Component: LayoutSettingPage };
+        },
+      },
+      {
+        path: PATH.statistics,
+        async lazy(): Promise<{ Component: React.FC }> {
+          const { ShopStatisticsPage } = await import('./ShopStatisticsPage');
+          return { Component: ShopStatisticsPage };
+        },
+      },
+      {
+        path: PATH.setting,
+        async lazy(): Promise<{ Component: React.FC }> {
+          const { ShopSettingPage } = await import('./ShopSettingPage');
+          return { Component: ShopSettingPage };
+        },
+      },
+    ],
+  },
+
+  {
+    path: '*',
+    element: <div>Wrong Access</div>,
+  },
+]);

--- a/src/pages/ShopSettingPage/index.tsx
+++ b/src/pages/ShopSettingPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const ShopSettingPage: React.FC = () => {
+  return <div>ShopSettingPage</div>;
+};

--- a/src/pages/ShopStatisticsPage/index.tsx
+++ b/src/pages/ShopStatisticsPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const ShopStatisticsPage: React.FC = () => {
+  return <div>ShopStatisticsPage</div>;
+};

--- a/src/pages/ShopStatusPage/index.tsx
+++ b/src/pages/ShopStatusPage/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const ShopStatusPage: React.FC = () => {
+  return <div>ShopStatusPage</div>;
+};

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,4 +1,4 @@
-import { ReportHandler } from 'web-vitals';
+import type { ReportHandler } from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,6 +1699,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.6.3.tgz#8205baf6e17ef93be35bf62c37d2d594e9be0dad"
+  integrity sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7946,6 +7951,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.12.0.tgz#372279caaaa1ffb0204926c83e93a139b112d861"
+  integrity sha512-UzLwZ3ZVaDr6YV0HdjwxuwtDKgwpJx9o1ea9fU0HV4tTvzdB8WPHzlLFMo5orchpIS84e8G4Erlhu7Rl84XDFQ==
+  dependencies:
+    "@remix-run/router" "1.6.3"
+    react-router "6.12.0"
+
+react-router@6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.12.0.tgz#1afae9219c24c8611809469d7a386c8023ade39a"
+  integrity sha512-/tCGtLq9umxRvbYeIx3j94CmpQfue0E3qnetVm9luKhu58cR4t+3O4ZrQXBdXfJrBATOAj+wF/1ihJJQI8AoTw==
+  dependencies:
+    "@remix-run/router" "1.6.3"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## 기획 및 구현한 내용

<!-- 구현한 기능에 관련된 기획을 서술 -->
user 레포와 동일하게 react router 라이브러리 설치해서 라우팅 설정했습니다

## 변경사항

<!-- 주요 변경점 서술 -->

1. 각 페이지 별 파일 만들어놨음
2. `AuthGuard` 컴포넌트: 로그인 후에 보여줄 수 있는 컴포넌트들을 감싸기 위한 컴포넌트. 로그인 되지 않으면 login 페이지로 리다이렉션 시키려고 만들어놓음. 근데 아직 login 로직을 작성안해놔서 컴포넌트만 만들어놈
3. `GustGuard` 컴포넌트: 로그인이 안된 상태에서 보여줄 컴포넌트를 감싸기 위한 컴포넌트.
4. user 레포와 다르게 signup 대신 join이라는 변수명을 씀
  => 이유: 회원가입을 signup이라는 용어로 쓸거면 로그인은 signin으로 하는 게 더 적합하다고 봄. 하지만 로그인을 'login'이라는 용어를 쓸것이므로 회원가입을 'join'이라는 용어로 바꿨음. 나중에 user 레포도 'join'으로 바꾸려고 함..
5. 기본 경로 'localhost:3000'에 들어갔을 때 보여주는 페이지는 가게 현황 페이지임.(`<ShopStatusPage>`)


## 테스트 방법

yarn install && yarn start로 실행 후

<img width="317" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/943bd43c-3fa9-411c-88d8-f43efbde220c">    

`src/common/utils/constants.ts`에 있는 경로 값으로 접속해보며 테스트해본다.

ex) `localhost:3000/join` 접속 -> 회원가입 페이지
ex) `localhost:3000/statistics` 접속 -> 통계 페이지

<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)

<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [x] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [x] 이슈 상태를 업데이트 함.
