### PR TITLE
[Feature/#9] 회원가입 페이지 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.26",
+    "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.0-next.1",
     "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
     "styled-components": "5.3.10",

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const ENDPOINT = process.env.REACT_APP_API_URL;
+
+export const axiosClient = axios.create({
+  baseURL: ENDPOINT,
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+});

--- a/src/api/lib/auth.ts
+++ b/src/api/lib/auth.ts
@@ -1,0 +1,47 @@
+import type { JoinFormInputs } from 'common/utils/types';
+import { axiosClient } from 'api/apiClient';
+
+export function signUp({
+  email,
+  password,
+  passwordChecked,
+  nickname,
+  age,
+  sex,
+  consentToMarketing,
+  consentToTermsOfUser,
+  employerIdNumber,
+  openDate,
+  adminName,
+}: JoinFormInputs) {
+  return axiosClient.post('/admins/sign-up', {
+    email,
+    password,
+    passwordChecked,
+    nickname,
+    age,
+    sex,
+    consentToMarketing: true,
+    consentToTermsOfUser: true,
+    employerIdNumber,
+    openDate,
+    adminName,
+  });
+}
+
+// 로그인 미완
+export function signIn(email: string, password: string) {
+  return axiosClient.post('/admins/sign-in', {});
+}
+
+export function validateNickname(nickname: string) {
+  return axiosClient.post('/admins/validate/nickname', {
+    nickname,
+  });
+}
+
+export function validateEmail(email: string) {
+  return axiosClient.post('/admins/validate/email', {
+    email,
+  });
+}

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -1,0 +1,14 @@
+export interface JoinFormInputs {
+  email: string;
+  password: string;
+  passwordChecked: string;
+  nickname: string;
+  age: number;
+  sex: string;
+  employerIdNumber: string;
+  openDate: string;
+  adminName: string;
+  // 추가
+  consentToMarketing: boolean;
+  consentToTermsOfUser: boolean;
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,6 +7,7 @@ interface ButtonProps extends React.HtmlHTMLAttributes<HTMLButtonElement> {
   width?: string;
   height?: string;
   borderRadius?: string;
+  type?: 'submit' | 'button' | 'reset' | undefined;
 }
 
 /**
@@ -18,12 +19,13 @@ export const Button: React.FC<ButtonProps> = ({
   height = '5.6rem',
   borderRadius = '0.8rem',
   isDisabled,
+  type = 'submit',
   children,
   ...rest
 }) => {
   return (
     <StyledButton
-      type='button'
+      type={type}
       onClick={onClick}
       disabled={isDisabled}
       width={width}

--- a/src/components/Input.styled.ts
+++ b/src/components/Input.styled.ts
@@ -2,26 +2,6 @@ import styled from 'styled-components/macro';
 
 export const Wrap = styled.div``;
 
-export const Label = styled.label``;
-
-export const LabelText = styled.p`
-  margin-bottom: 0.8rem;
-
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 2.4rem;
-  color: black;
-  opacity: 0.8;
-`;
-
-export const RequiredAsterisk = styled.span`
-  font-weight: 600;
-  font-size: 1.3rem;
-  line-height: 2rem;
-  color: #da1414;
-  vertical-align: top;
-`;
-
 export const StyledInput = styled.input`
   padding: 0 1.6rem;
 
@@ -33,4 +13,10 @@ export const StyledInput = styled.input`
   font-weight: 600;
   font-size: 1.6rem;
   line-height: 2.4rem;
+
+  // 인풋창 테두리
+  &:focus-visible {
+    outline: 0.2rem solid ${({ theme }) => theme.palette.primary.orange};
+    outline-offset: -0.2rem;
+  }
 `;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import {
   Label,
   LabelText,
@@ -6,30 +8,32 @@ import {
   RequiredAsterisk,
 } from 'components/Input.styled';
 
-interface InputProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
+interface InputProps
+  extends React.HtmlHTMLAttributes<HTMLDivElement & HTMLInputElement> {
   label: string;
   placeholder: string;
-  required?: boolean;
+  required?: boolean; // false면 * 표시 숨김
 }
 
 /**
  * 인풋 컴포넌트
  */
-export const Input: React.FC<InputProps> = ({
-  label,
-  placeholder,
-  required = true,
-  ...rest
-}) => {
-  return (
-    <Wrap {...rest}>
-      <Label>
-        <LabelText>
-          {label}
-          {required && <RequiredAsterisk>*</RequiredAsterisk>}
-        </LabelText>
-        <StyledInput placeholder={placeholder} />
-      </Label>
-    </Wrap>
-  );
-};
+export const Input = forwardRef(
+  (
+    { label, placeholder, required = true, ...rest }: InputProps,
+    ref: Ref<HTMLInputElement>,
+  ) => {
+    return (
+      // TODO rest 처리
+      <Wrap>
+        <Label>
+          <LabelText>
+            {label}
+            {required && <RequiredAsterisk>*</RequiredAsterisk>}
+          </LabelText>
+          <StyledInput placeholder={placeholder} ref={ref} {...rest} />
+        </Label>
+      </Wrap>
+    );
+  },
+);

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,18 +1,13 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
-import {
-  Label,
-  LabelText,
-  StyledInput,
-  Wrap,
-  RequiredAsterisk,
-} from 'components/Input.styled';
+import { StyledInput, Wrap } from 'components/Input.styled';
+import { Label } from 'components/Label';
 
-interface InputProps
-  extends React.HtmlHTMLAttributes<HTMLDivElement & HTMLInputElement> {
+interface InputProps extends React.HtmlHTMLAttributes<HTMLInputElement> {
   label: string;
-  placeholder: string;
   required?: boolean; // false면 * 표시 숨김
+  placeholder?: string;
+  type?: React.HTMLInputTypeAttribute;
 }
 
 /**
@@ -20,18 +15,25 @@ interface InputProps
  */
 export const Input = forwardRef(
   (
-    { label, placeholder, required = true, ...rest }: InputProps,
+    {
+      label,
+      placeholder = '',
+      required = true,
+      type = 'text',
+      ...rest
+    }: InputProps,
     ref: Ref<HTMLInputElement>,
   ) => {
     return (
       // TODO rest 처리
       <Wrap>
-        <Label>
-          <LabelText>
-            {label}
-            {required && <RequiredAsterisk>*</RequiredAsterisk>}
-          </LabelText>
-          <StyledInput placeholder={placeholder} ref={ref} {...rest} />
+        <Label label={label} required={required}>
+          <StyledInput
+            type={type}
+            placeholder={placeholder}
+            ref={ref}
+            {...rest}
+          />
         </Label>
       </Wrap>
     );

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,7 +3,7 @@ import type { Ref } from 'react';
 import { StyledInput, Wrap } from 'components/Input.styled';
 import { Label } from 'components/Label';
 
-interface InputProps extends React.HtmlHTMLAttributes<HTMLInputElement> {
+interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
   label: string;
   required?: boolean; // false면 * 표시 숨김
   placeholder?: string;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+interface LabelProps {
+  label: string;
+  required?: boolean; // false면 * 표시 숨김
+  children?: React.ReactNode;
+}
+
+/**
+ * 인풋 위에 달려있는 라벨 문구
+ */
+export const Label: React.FC<LabelProps> = ({
+  label,
+  required = true,
+  children,
+}) => {
+  return (
+    <StyledLabel>
+      <LabelText>
+        {label}
+        {required && <RequiredAsterisk>*</RequiredAsterisk>}
+      </LabelText>
+      {children}
+    </StyledLabel>
+  );
+};
+
+const StyledLabel = styled.label``;
+
+const LabelText = styled.p`
+  margin-bottom: 0.8rem;
+
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+  color: black;
+  opacity: 0.8;
+`;
+
+const RequiredAsterisk = styled.span`
+  font-weight: 600;
+  font-size: 1.3rem;
+  line-height: 2rem;
+  color: #da1414;
+  vertical-align: top;
+`;

--- a/src/components/Radio.tsx
+++ b/src/components/Radio.tsx
@@ -1,0 +1,79 @@
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+import type { Ref } from 'react';
+
+interface RadioProps extends React.HtmlHTMLAttributes<HTMLInputElement> {
+  id: string;
+  name: string; // radio group 내에서 동일한 이름 사용해야함
+  value: string;
+  label: string;
+}
+
+/**
+ * radio input 컴포넌트 (회원가입 페이지에서 사용)
+ */
+export const Radio = forwardRef(
+  (
+    { id, name, value, label, ...rest }: RadioProps,
+    ref: Ref<HTMLInputElement>,
+  ) => {
+    return (
+      <Label htmlFor={id}>
+        <RadioInput
+          type='radio'
+          id={id}
+          name={name}
+          value={value}
+          ref={ref}
+          {...rest}
+        />
+        <LabelText>{label}</LabelText>
+      </Label>
+    );
+  },
+);
+
+const Label = styled.label`
+  display: inline-flex;
+  align-items: center;
+  /* background-color: aqua; */
+`;
+
+const LabelText = styled.span`
+  font-weight: 400;
+  font-size: 1.6rem;
+  line-height: 1.8rem;
+  color: ${({ theme }) => theme.palette.grey[400]};
+  margin-left: 1.6rem;
+`;
+
+const RadioInput = styled.input`
+  &[type='radio'] {
+    appearance: none;
+
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+
+    border: 0.15rem solid ${({ theme }) => theme.palette.grey[200]};
+    background-color: ${({ theme }) => theme.palette.grey[50]};
+
+    transition: border 0.2s ease-in-out;
+  }
+  &[type='radio']:checked {
+    width: 2.4rem;
+    height: 2.4rem;
+    outline: 0.3rem solid ${({ theme }) => theme.palette.primary.orange};
+    border: 0.3rem solid white;
+    background-color: ${({ theme }) => theme.palette.primary.orange};
+    margin: 0.3rem;
+  }
+
+  &[type='radio']:hover {
+    filter: brightness(95%);
+    cursor: pointer;
+  }
+  &[type='radio']:hover + span {
+    cursor: pointer;
+  }
+`;

--- a/src/pages/JoinPage/components/AdminInfo.styled.ts
+++ b/src/pages/JoinPage/components/AdminInfo.styled.ts
@@ -1,12 +1,18 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components/macro';
-import { Input } from 'components/Input';
+import { ErrorMessage } from 'components/ErrorMessage';
 import { flexSet } from 'styles/mixin';
 
-export const GappedInput = styled(Input)`
+export const Form = styled.form``;
+
+export const InputWrap = styled.div`
   & + & {
     margin-top: 6.8rem;
   }
+`;
+
+export const GappedErrorMessage = styled(ErrorMessage)`
+  margin-top: 0.8rem;
 `;
 
 export const LoginRow = styled.div`

--- a/src/pages/JoinPage/components/AdminInfo.styled.ts
+++ b/src/pages/JoinPage/components/AdminInfo.styled.ts
@@ -11,6 +11,14 @@ export const InputWrap = styled.div`
   }
 `;
 
+export const RadioRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4rem;
+
+  padding-top: 0.8rem;
+`;
+
 export const GappedErrorMessage = styled(ErrorMessage)`
   margin-top: 0.8rem;
 `;

--- a/src/pages/JoinPage/components/AdminInfo.tsx
+++ b/src/pages/JoinPage/components/AdminInfo.tsx
@@ -1,10 +1,14 @@
-import { useForm } from 'react-hook-form';
+import { useEffect } from 'react';
 import { Form } from 'react-router-dom';
-import type { StoreInfoProps } from 'pages/JoinPage/components/StoreInfo';
-import type { SubmitHandler } from 'react-hook-form';
+import type { JoinFormInputs } from 'common/utils/types';
+import type { InnerPageProps } from 'pages/JoinPage/utils/types';
+import type { SubmitHandler, ChangeHandler } from 'react-hook-form';
+import { validateEmail, validateNickname } from 'api/lib/auth';
 import { PATH } from 'common/utils/constants';
 import { Button } from 'components/Button';
 import { Input } from 'components/Input';
+import { Label } from 'components/Label';
+import { Radio } from 'components/Radio';
 import {
   LoginLink,
   LoginRow,
@@ -12,35 +16,82 @@ import {
   BottomWrap,
   GappedErrorMessage,
   InputWrap,
+  RadioRow,
 } from 'pages/JoinPage/components/AdminInfo.styled';
-
-interface FormInputs {
-  email: string;
-  password: string;
-  nickname: string;
-  age: number;
-}
 
 /**
  * 관리자 회원가입 > 첫 번쨰 화면에서 보여줄 컴포넌트 (관리자 정보 입력 페이지)
  */
-export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
+export const AdminInfo: React.FC<InnerPageProps> = ({
+  onClickNext,
+  useJoinForm,
+}) => {
   const {
     register,
+    setError,
+    getValues,
+    clearErrors,
+    formState: { errors, isValid },
     handleSubmit,
-    formState: { errors },
-  } = useForm<FormInputs>({ mode: 'onChange' });
+  } = useJoinForm;
 
-  const onSubmit: SubmitHandler<FormInputs> = (data) => {
-    console.log(data);
+  const onSubmit: SubmitHandler<JoinFormInputs> = () => {
     onClickNext('SECOND');
+    window.history.pushState({ page: 1 }, '');
+  };
+
+  const handleValidateNickname: ChangeHandler = async (e) => {
+    if (errors.nickname) return;
+    try {
+      const response = await validateNickname(e.target.value);
+
+      const isValidNickname = response.data.result.isValid;
+      if (!isValidNickname) {
+        setError('nickname', { message: '중복된 닉네임입니다.' });
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleValidateEmail: ChangeHandler = async (event) => {
+    if (errors.email) return;
+    try {
+      const response = await validateEmail(event.target.value);
+
+      const isValidEmail = response.data.result.isValid;
+      if (!isValidEmail) {
+        setError('email', { message: '중복된 이메일입니다.' });
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleValidatePassword = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const passwordChecked = getValues('passwordChecked');
+    if (
+      passwordChecked.length === 0 ||
+      errors.passwordChecked?.type === 'pattern'
+    ) {
+      return;
+    }
+    const password = event.target.value;
+    if (password === getValues('passwordChecked')) {
+      clearErrors('passwordChecked');
+    } else {
+      setError('passwordChecked', {
+        message: '비밀번호가 일치하지 않습니다.',
+      });
+    }
   };
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <InputWrap>
         <Input
-          className='hi'
           label='이메일'
           placeholder='이메일을 입력해주세요'
           {...register('email', {
@@ -49,6 +100,7 @@ export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
               value: /\S+@\S+\.\S+/,
               message: '@를 포함한 이메일 형식으로 작성해 주세요.',
             },
+            onBlur: handleValidateEmail,
           })}
         />
         {errors.email && (
@@ -59,16 +111,42 @@ export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
         <Input
           label='비밀번호'
           placeholder='비밀번호를 입력해주세요'
+          type='password'
           {...register('password', {
             required: '비밀번호는 필수 입력입니다.',
             pattern: {
               value: /^(?=.*[a-zA-Z])((?=.*\d)(?=.*\W)).{8,20}$/,
               message: '영문, 숫자, 특수기호를 포함하여 8~20자로 입력해주세요.',
             },
+            onChange: handleValidatePassword,
           })}
         />
         {errors.password && (
           <GappedErrorMessage>{errors.password?.message}</GappedErrorMessage>
+        )}
+      </InputWrap>
+      <InputWrap>
+        <Input
+          label='비밀번호 확인'
+          placeholder='비밀번호를 한번 더 입력해주세요'
+          type='password'
+          {...register('passwordChecked', {
+            required: '비밀번호는 필수 입력입니다.',
+            pattern: {
+              value: /^(?=.*[a-zA-Z])((?=.*\d)(?=.*\W)).{8,20}$/,
+              message: '영문, 숫자, 특수기호를 포함하여 8~20자로 입력해주세요.',
+            },
+            validate: {
+              isSame: (value, formValues: JoinFormInputs) =>
+                value === formValues.password ||
+                '비밀번호가 일치하지 않습니다.',
+            },
+          })}
+        />
+        {errors.passwordChecked && (
+          <GappedErrorMessage>
+            {errors.passwordChecked?.message}
+          </GappedErrorMessage>
         )}
       </InputWrap>
       <InputWrap>
@@ -82,6 +160,7 @@ export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
               message:
                 '2~10자의 한글, 영문(대소문자 포함), 숫자만 입력가능합니다.',
             },
+            onBlur: handleValidateNickname,
           })}
         />
         {errors.nickname && (
@@ -106,14 +185,24 @@ export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
         )}
       </InputWrap>
       <InputWrap>
-        <Input
-          className='gap'
-          label='성별'
-          placeholder='이메일을 입력해주세요'
-        />
+        <Label label='성별' />
+        <RadioRow>
+          <Radio
+            id='female'
+            label='여성'
+            value='여성'
+            {...register('sex', { required: '성별을 선택해주세요.' })}
+          />
+          <Radio
+            id='male'
+            label='남성'
+            value='남성'
+            {...register('sex', { required: '성별을 선택해주세요.' })}
+          />
+        </RadioRow>
       </InputWrap>
       <BottomWrap>
-        <Button>다음</Button>
+        <Button isDisabled={!isValid}>다음</Button>
         <LoginRow>
           <Description>이미 계정이 있나요?</Description>
           <LoginLink to={`/${PATH.login}`}>로그인하기</LoginLink>

--- a/src/pages/JoinPage/components/AdminInfo.tsx
+++ b/src/pages/JoinPage/components/AdminInfo.tsx
@@ -1,31 +1,124 @@
-import type { InnerPageProps, JoinStatus } from 'pages/JoinPage/utils/types';
+import { useForm } from 'react-hook-form';
+import { Form } from 'react-router-dom';
+import type { StoreInfoProps } from 'pages/JoinPage/components/StoreInfo';
+import type { SubmitHandler } from 'react-hook-form';
 import { PATH } from 'common/utils/constants';
 import { Button } from 'components/Button';
+import { Input } from 'components/Input';
 import {
   LoginLink,
   LoginRow,
   Description,
-  GappedInput,
   BottomWrap,
+  GappedErrorMessage,
+  InputWrap,
 } from 'pages/JoinPage/components/AdminInfo.styled';
+
+interface FormInputs {
+  email: string;
+  password: string;
+  nickname: string;
+  age: number;
+}
+
 /**
  * 관리자 회원가입 > 첫 번쨰 화면에서 보여줄 컴포넌트 (관리자 정보 입력 페이지)
  */
-export const AdminInfo: React.FC<InnerPageProps> = ({ onClickNext }) => {
+export const AdminInfo: React.FC<StoreInfoProps> = ({ onClickNext }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormInputs>({ mode: 'onChange' });
+
+  const onSubmit: SubmitHandler<FormInputs> = (data) => {
+    console.log(data);
+    onClickNext('SECOND');
+  };
+
   return (
-    <div>
-      <GappedInput label='이메일' placeholder='이메일을 입력해주세요' />
-      <GappedInput label='비밀번호' placeholder='비밀번호를 입력해주세요' />
-      <GappedInput label='닉네임' placeholder='닉네임을 입력해주세요' />
-      <GappedInput label='나이' placeholder='나이를 입력해주세요' />
-      <GappedInput label='성별' placeholder='이메일을 입력해주세요' />
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <InputWrap>
+        <Input
+          className='hi'
+          label='이메일'
+          placeholder='이메일을 입력해주세요'
+          {...register('email', {
+            required: '이메일은 필수 입력입니다.',
+            pattern: {
+              value: /\S+@\S+\.\S+/,
+              message: '@를 포함한 이메일 형식으로 작성해 주세요.',
+            },
+          })}
+        />
+        {errors.email && (
+          <GappedErrorMessage>{errors.email?.message}</GappedErrorMessage>
+        )}
+      </InputWrap>
+      <InputWrap>
+        <Input
+          label='비밀번호'
+          placeholder='비밀번호를 입력해주세요'
+          {...register('password', {
+            required: '비밀번호는 필수 입력입니다.',
+            pattern: {
+              value: /^(?=.*[a-zA-Z])((?=.*\d)(?=.*\W)).{8,20}$/,
+              message: '영문, 숫자, 특수기호를 포함하여 8~20자로 입력해주세요.',
+            },
+          })}
+        />
+        {errors.password && (
+          <GappedErrorMessage>{errors.password?.message}</GappedErrorMessage>
+        )}
+      </InputWrap>
+      <InputWrap>
+        <Input
+          label='닉네임'
+          placeholder='닉네임을 입력해주세요'
+          {...register('nickname', {
+            required: '닉네임은 필수 입력입니다.',
+            pattern: {
+              value: /^[A-Za-z0-9ㄱ-ㅎ가-힣]{2,10}$/,
+              message:
+                '2~10자의 한글, 영문(대소문자 포함), 숫자만 입력가능합니다.',
+            },
+          })}
+        />
+        {errors.nickname && (
+          <GappedErrorMessage>{errors.nickname?.message}</GappedErrorMessage>
+        )}
+      </InputWrap>
+      <InputWrap>
+        <Input
+          className='gap'
+          label='나이'
+          placeholder='나이를 입력해주세요'
+          {...register('age', {
+            required: '나이는 필수 입력입니다.',
+            pattern: {
+              value: /^(?:[1-9]|[1-9][0-9])$/,
+              message: '유효한 나이를 입력해주세요.',
+            },
+          })}
+        />
+        {errors.age && (
+          <GappedErrorMessage>{errors.age?.message}</GappedErrorMessage>
+        )}
+      </InputWrap>
+      <InputWrap>
+        <Input
+          className='gap'
+          label='성별'
+          placeholder='이메일을 입력해주세요'
+        />
+      </InputWrap>
       <BottomWrap>
-        <Button onClick={() => onClickNext('SECOND')}>다음</Button>
+        <Button>다음</Button>
         <LoginRow>
           <Description>이미 계정이 있나요?</Description>
           <LoginLink to={`/${PATH.login}`}>로그인하기</LoginLink>
         </LoginRow>
       </BottomWrap>
-    </div>
+    </Form>
   );
 };

--- a/src/pages/JoinPage/components/StoreInfo.styled.ts
+++ b/src/pages/JoinPage/components/StoreInfo.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { Input } from 'components/Input';
+import { ErrorMessage } from 'components/ErrorMessage';
 
-export const GappedInput = styled(Input)`
+export const InputWrap = styled.div`
   & + & {
     margin-top: 6.8rem;
   }
@@ -10,4 +10,8 @@ export const GappedInput = styled(Input)`
 export const BottomWrap = styled.div`
   margin-top: 6.8rem;
   margin-bottom: 9.8rem;
+`;
+
+export const GappedErrorMessage = styled(ErrorMessage)`
+  margin-top: 0.8rem;
 `;

--- a/src/pages/JoinPage/components/StoreInfo.tsx
+++ b/src/pages/JoinPage/components/StoreInfo.tsx
@@ -1,21 +1,41 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { InnerPageProps, JoinStatus } from 'pages/JoinPage/utils/types';
+import type { InnerPageProps } from 'pages/JoinPage/utils/types';
+import type { UseFormHandleSubmit } from 'react-hook-form';
 import { Button } from 'components/Button';
 import {
   BottomWrap,
   GappedInput,
 } from 'pages/JoinPage/components/StoreInfo.styled';
 
+export interface StoreInfoProps extends InnerPageProps {
+  handleSubmit: UseFormHandleSubmit<any, undefined>;
+}
+
 /**
  * 관리자 회원가입 > 두 번째 화면에서 보여줄 컴포넌트 (가게 정보 입력 페이지)
  */
-export const StoreInfo: React.FC<InnerPageProps> = ({ onClickNext }) => {
+export const StoreInfo: React.FC<StoreInfoProps> = ({
+  onClickNext,
+  handleSubmit,
+}) => {
   const navigate = useNavigate();
 
   const handleClickJoin = () => {
-    onClickNext('FIRST'); // 초기화
-    navigate('/', { replace: true });
+    // try {
+    //   const res = await signUp('sumin@email.com', 'sumin12345');
+    //   console.log('res :>> ', res);
+    // } catch (e) {
+    //   console.log('e :>> ', e);
+    //   // e.response.status === 500 // 서버 연결 실패
+    // }
+
+    // onClickNext('FIRST'); // 초기화
+    // navigate('/', { replace: true });
+
+    handleSubmit((data) => {
+      console.log('data:>>', data);
+    });
   };
 
   // 뒤로가기 발생 시 회원가입 첫번쨰 페이지로 전환

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import type { JoinFormInputs } from 'common/utils/types';
 import type { JoinStatus } from 'pages/JoinPage/utils/types';
+import type { UseFormReturn } from 'react-hook-form';
 import { AdminInfo } from 'pages/JoinPage/components/AdminInfo';
 import { StoreInfo } from 'pages/JoinPage/components/StoreInfo';
 import {
@@ -20,7 +22,10 @@ import {
  * 회원가입 페이지
  */
 export const JoinPage: React.FC = () => {
-  const { register, handleSubmit } = useForm();
+  const useJoinForm: UseFormReturn<JoinFormInputs> = useForm<JoinFormInputs>({
+    mode: 'onChange',
+  });
+
   const [joinStatus, setJoinStatus] = useState<JoinStatus>('FIRST');
 
   const handleSwitchPage = (status: JoinStatus) => {
@@ -48,14 +53,12 @@ export const JoinPage: React.FC = () => {
           {joinStatus === 'FIRST' ? (
             <AdminInfo
               onClickNext={handleSwitchPage}
-              register={register}
-              handleSubmit={handleSubmit}
+              useJoinForm={useJoinForm}
             />
           ) : (
             <StoreInfo
-              register={register}
               onClickNext={handleSwitchPage}
-              handleSubmit={handleSubmit}
+              useJoinForm={useJoinForm}
             />
           )}
         </RightContentWrap>

--- a/src/pages/JoinPage/index.tsx
+++ b/src/pages/JoinPage/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import type { JoinStatus } from 'pages/JoinPage/utils/types';
 import { AdminInfo } from 'pages/JoinPage/components/AdminInfo';
 import { StoreInfo } from 'pages/JoinPage/components/StoreInfo';
@@ -19,6 +20,7 @@ import {
  * 회원가입 페이지
  */
 export const JoinPage: React.FC = () => {
+  const { register, handleSubmit } = useForm();
   const [joinStatus, setJoinStatus] = useState<JoinStatus>('FIRST');
 
   const handleSwitchPage = (status: JoinStatus) => {
@@ -44,9 +46,17 @@ export const JoinPage: React.FC = () => {
             <ProgressText>{joinStatus === 'FIRST' ? 1 : 2}/2</ProgressText>
           </ProgressWrap>
           {joinStatus === 'FIRST' ? (
-            <AdminInfo onClickNext={handleSwitchPage} />
+            <AdminInfo
+              onClickNext={handleSwitchPage}
+              register={register}
+              handleSubmit={handleSubmit}
+            />
           ) : (
-            <StoreInfo onClickNext={handleSwitchPage} />
+            <StoreInfo
+              register={register}
+              onClickNext={handleSwitchPage}
+              handleSubmit={handleSubmit}
+            />
           )}
         </RightContentWrap>
       </RightSide>

--- a/src/pages/JoinPage/utils/types.ts
+++ b/src/pages/JoinPage/utils/types.ts
@@ -1,8 +1,9 @@
-import type { UseFormRegister } from 'react-hook-form';
+import type { JoinFormInputs } from 'common/utils/types';
+import type { UseFormReturn } from 'react-hook-form';
 
 export type JoinStatus = 'FIRST' | 'SECOND';
 
 export interface InnerPageProps {
   onClickNext: (status: JoinStatus) => void;
-  register: UseFormRegister<any>;
+  useJoinForm: UseFormReturn<JoinFormInputs>;
 }

--- a/src/pages/JoinPage/utils/types.ts
+++ b/src/pages/JoinPage/utils/types.ts
@@ -1,5 +1,8 @@
+import type { UseFormRegister } from 'react-hook-form';
+
 export type JoinStatus = 'FIRST' | 'SECOND';
 
 export interface InnerPageProps {
   onClickNext: (status: JoinStatus) => void;
+  register: UseFormRegister<any>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.1.1.tgz#3b6e5c6d4e43ca7ba51c5babf99d22a9c68485e1"
@@ -4776,7 +4785,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -4811,6 +4820,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -7815,6 +7833,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7955,6 +7955,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-hook-form@^7.45.0-next.1:
+  version "7.45.0-next.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.0-next.1.tgz#ec9ca4ade908e80d8a8430707d4ce12af0f55ad6"
+  integrity sha512-ksvvJm6c+rBl6XbXGj4GJhL073DRkIsDv0fvunaueeIC2ydp9YKozt8ofNEPimQ9XU3HOI+wuQBkXtYmVJCEpQ==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 기획 및 구현한 내용

<!-- 구현한 기능에 관련된 기획을 서술 -->

회원가입 페이지 퍼블리싱 보완 (라디오버튼 추가) & API 연결 작업 했습니다

## 변경사항

- 유저 레포랑 동일한 라이브러리 설치했습니다
1. react-hook-form 
2. axios

<!-- 주요 변경점 서술 -->

## 테스트 방법

1. .env 파일 생성 후 노션 '환경 변수' 문서에 있는 내용 복붙해넣기
2. yarn install && yarn start 로 실행
3. localhost:3000/join 으로 접속
4. 회원가입 진행하며 유효성 검사가 잘 되는지 확인
5. 회원가입을 진행한 후 동일한 이메일, 닉네임으로 한번 더 회원가입 진행. 이때 중복 검사가 잘되는지 확인

유효성 검사 빠트린 부분 있는지, 퍼블리싱 아쉬운 점 있는지, 코드 개선점 있는지 위주로 봐주시면 감사하겠습니다 ^^
<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)
<img width="1385" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/8dbc8820-322e-4cee-a628-6e46fadc3971">

<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [x] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [ ] 이슈 상태를 업데이트 함.
