### PR TITLE
[Feature/#12] 가게 설정 페이지 일부 퍼블리싱 (사이드바, 헤더)

### DIFF
--- a/src/assets/icons/plus-circle.svg
+++ b/src/assets/icons/plus-circle.svg
@@ -1,0 +1,7 @@
+<svg width="3.2rem" height="3.2rem" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="plus-circle">
+<path id="Vector" d="M15.9993 29.3334C23.3631 29.3334 29.3327 23.3639 29.3327 16.0001C29.3327 8.63628 23.3631 2.66675 15.9993 2.66675C8.63555 2.66675 2.66602 8.63628 2.66602 16.0001C2.66602 23.3639 8.63555 29.3334 15.9993 29.3334Z" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M16 10.6667V21.3334" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M10.666 16H21.3327" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/DashboardLayout/components/GlobalNavigationBar.styled.ts
+++ b/src/components/DashboardLayout/components/GlobalNavigationBar.styled.ts
@@ -8,7 +8,7 @@ export const Wrap = styled.div<{ folded: boolean }>`
   padding: 8rem 0;
 
   width: ${({ folded }): string => (folded ? '9.6rem' : '31.5rem')};
-  height: 100%;
+  min-height: 100vh; // 필요
   background-color: #303030;
 
   .shopLogo {

--- a/src/components/DashboardLayout/index.tsx
+++ b/src/components/DashboardLayout/index.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { GlobalNavigationBar } from 'components/DashboardLayout/components/GlobalNavigationBar';
 
 /**
@@ -16,7 +16,6 @@ export const DashboardLayout: React.FC = () => {
 
 const Wrap = styled.div`
   display: flex;
-  height: 100%;
 
   /* background-color: yellow; */
 `;

--- a/src/components/ErrorMessage.styled.ts
+++ b/src/components/ErrorMessage.styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Wrap = styled.div<{ width: string; height: string }>`
   display: flex;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 interface LabelProps {
   label: string;

--- a/src/components/Radio.tsx
+++ b/src/components/Radio.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import type { Ref } from 'react';
 
 interface RadioProps extends React.HtmlHTMLAttributes<HTMLInputElement> {

--- a/src/components/SideBar.ts
+++ b/src/components/SideBar.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const SideBar = styled.div`
   width: 46.1rem;

--- a/src/components/Tabs.tsx/index.tsx
+++ b/src/components/Tabs.tsx/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import type React from 'react';
 import { TabNavItem } from 'components/Tabs.tsx/components/TabNavItem';
 
@@ -10,12 +10,13 @@ export interface TabItem {
 
 interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
   tabList: TabItem[];
+  tabWidth?: string;
 }
 
 /**
  * 탭 메뉴 컴포넌트
  */
-export const Tabs: React.FC<TabsProps> = ({ tabList, ...rest }) => {
+export const Tabs: React.FC<TabsProps> = ({ tabList, tabWidth, ...rest }) => {
   const [activeTab, setActiveTab] = useState(0);
 
   const onClickItem = (index: number) => {
@@ -36,7 +37,7 @@ export const Tabs: React.FC<TabsProps> = ({ tabList, ...rest }) => {
 
   return (
     <Wrap {...rest}>
-      <TabContainer>{tabNavItemList}</TabContainer>
+      <TabContainer tabWidth={tabWidth}>{tabNavItemList}</TabContainer>
       {tabList[activeTab].content}
     </Wrap>
   );
@@ -44,9 +45,12 @@ export const Tabs: React.FC<TabsProps> = ({ tabList, ...rest }) => {
 
 const Wrap = styled.div`
   height: 6rem;
+
+  width: 100%;
 `;
 
-const TabContainer = styled.ul`
+const TabContainer = styled.ul<{ tabWidth?: string }>`
+  max-width: ${({ tabWidth }) => tabWidth && tabWidth};
   display: flex;
   height: 100%;
 

--- a/src/pages/JoinPage/components/StoreInfo.styled.ts
+++ b/src/pages/JoinPage/components/StoreInfo.styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { ErrorMessage } from 'components/ErrorMessage';
 
 export const InputWrap = styled.div`

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import type { TabItem } from 'components/Tabs.tsx';
 import { SideBar } from 'components/SideBar';
 import { Tabs } from 'components/Tabs.tsx';

--- a/src/pages/ShopSettingPage/components/BusinessHourTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/BusinessHourTab/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const BusinessHourTab: React.FC = () => {
+  return <div>BusinessHourTab</div>;
+};

--- a/src/pages/ShopSettingPage/components/EmployerTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/EmployerTab/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * 컴포넌트
+ */
+export const EmployerTab: React.FC = () => {
+  return <div>직원 권한 설정</div>;
+};

--- a/src/pages/ShopSettingPage/components/SettingSideBar/ShopItem.styled.ts
+++ b/src/pages/ShopSettingPage/components/SettingSideBar/ShopItem.styled.ts
@@ -1,0 +1,58 @@
+import styled from 'styled-components/macro';
+
+export const Wrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  /* background-color: yellow; */
+  padding: 3rem 2.4rem;
+
+  width: 100%;
+  height: 11.5rem;
+
+  border-radius: 0.8rem;
+  border: 0.1rem solid ${({ theme }) => theme.palette.primary.orange};
+  background-color: white;
+
+  & + & {
+    margin-top: 1.6rem;
+  }
+`;
+
+export const Name = styled.p`
+  font-size: 2.4rem;
+  line-height: 2.4rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.palette.grey[500]};
+`;
+
+export const OpenStatus = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const Circle = styled.div`
+  margin-right: 0.7rem;
+
+  width: 0.8rem;
+  height: 0.8rem;
+
+  background-color: ${({ theme }) => theme.palette.grey[300]};
+  border-radius: 50%;
+`;
+
+export const Text = styled.p`
+  color: ${({ theme }) => theme.palette.grey[500]};
+  font-size: 1.6rem;
+  font-weight: 400;
+  line-height: normal;
+`;
+
+export const LeftWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  height: 100%;
+`;

--- a/src/pages/ShopSettingPage/components/SettingSideBar/ShopItem.tsx
+++ b/src/pages/ShopSettingPage/components/SettingSideBar/ShopItem.tsx
@@ -1,0 +1,32 @@
+import {
+  Circle,
+  LeftWrap,
+  Name,
+  OpenStatus,
+  Text,
+  Wrap,
+} from 'pages/ShopSettingPage/components/SettingSideBar/ShopItem.styled';
+import { Toggle } from 'pages/ShopSettingPage/components/SettingSideBar/Toggle';
+
+interface ShopItemProps {
+  name?: string | number;
+  func?: () => void;
+}
+
+/**
+ * 가게 아이템 컴포넌트
+ */
+export const ShopItem: React.FC<ShopItemProps> = ({ name, func }) => {
+  return (
+    <Wrap>
+      <LeftWrap>
+        <Name>{name}</Name>
+        <OpenStatus>
+          <Circle />
+          <Text>영업 준비 중</Text>
+        </OpenStatus>
+      </LeftWrap>
+      <Toggle />
+    </Wrap>
+  );
+};

--- a/src/pages/ShopSettingPage/components/SettingSideBar/Toggle.tsx
+++ b/src/pages/ShopSettingPage/components/SettingSideBar/Toggle.tsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components/macro';
+
+interface ToggleProps {
+  text?: string | number;
+}
+
+/**
+ * 컴포넌트
+ */
+export const Toggle: React.FC<ToggleProps> = ({ text }) => {
+  return (
+    <Wrap>
+      <input role='switch' type='checkbox' />
+    </Wrap>
+  );
+};
+
+const Wrap = styled.div`
+  [type='checkbox'] {
+    cursor: pointer;
+    appearance: none;
+
+    position: relative;
+    border: 0.16rem solid ${({ theme }) => theme.palette.grey[300]};
+    width: 5.3rem;
+    height: 3.2rem;
+    border-radius: 3.2rem;
+    background-color: ${({ theme }) => theme.palette.grey[300]};
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      width: 2.9em;
+      height: 2.9em;
+      border-radius: 50%;
+      /* transform: scale(0.8); */
+      background-color: white;
+      transition: all 250ms linear;
+    }
+  }
+
+  [type='checkbox']:checked {
+    background-color: ${({ theme }) => theme.palette.primary.orange};
+    border-color: ${({ theme }) => theme.palette.primary.orange};
+
+    &::before {
+      left: auto;
+      right: 0;
+      transition: all 250ms linear;
+    }
+  }
+`;

--- a/src/pages/ShopSettingPage/components/SettingSideBar/index.tsx
+++ b/src/pages/ShopSettingPage/components/SettingSideBar/index.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components/macro';
+import { ReactComponent as PlusCircleIcon } from 'assets/icons/plus-circle.svg';
+import { SideBar } from 'components/SideBar';
+import { ShopItem } from 'pages/ShopSettingPage/components/SettingSideBar/ShopItem';
+
+/**
+ * 컴포넌트
+ */
+export const SettingSideBar: React.FC = () => {
+  return (
+    <StyledSideBar>
+      <SideHeaderWrap>
+        <Title>전체 가게 관리</Title>
+        <button type='button'>
+          <PlusCircleIcon />
+        </button>
+      </SideHeaderWrap>
+
+      <ul>
+        <ShopItem name='hspace?' />
+        <ShopItem name='hspace?' />
+      </ul>
+    </StyledSideBar>
+  );
+};
+
+export const StyledSideBar = styled(SideBar)`
+  padding: 8rem 4rem;
+  /* min-height: 100vh; */
+  /* overflow: auto; */
+  /* background-color: aqua; */
+`;
+
+export const SideHeaderWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  margin-bottom: 2.4rem;
+`;
+
+export const Title = styled.h2`
+  font-size: 2.4rem;
+  font-weight: 500;
+
+  color: ${({ theme }) => theme.palette.grey[500]};
+`;

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 export const Wrap = styled.div`
   padding-top: 4rem;
   width: 100%;
-  background-color: red;
+  /* background-color: red; */
 `;
 
 export const ContentWrap = styled.ul`
   width: 53.9rem;
   margin: auto;
-  background-color: yellow;
+  /* background-color: yellow; */
 `;
 
 export const ListItem = styled.li`

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div`
+  padding-top: 4rem;
+  width: 100%;
+  background-color: red;
+`;
+
+export const ContentWrap = styled.ul`
+  width: 53.9rem;
+  margin: auto;
+  background-color: yellow;
+`;
+
+export const ListItem = styled.li`
+  & + & {
+    margin-top: 6.8rem;
+  }
+`;
+
+export const CurrentWifiBtn = styled.button`
+  width: 100%;
+  height: 4.2rem;
+  border-radius: 0.8rem;
+
+  background-color: ${({ theme }) => theme.palette.grey[500]};
+
+  color: white;
+  font-size: 1.4rem;
+  font-weight: 500;
+
+  &:hover {
+    filter: brightness(95%);
+  }
+`;
+
+export const RadioRow = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 4rem;
+
+  padding-top: 0.8rem;
+`;

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
@@ -1,0 +1,74 @@
+import { Input } from 'components/Input';
+import { Label } from 'components/Label';
+import { Radio } from 'components/Radio';
+import {
+  ContentWrap,
+  CurrentWifiBtn,
+  ListItem,
+  RadioRow,
+  Wrap,
+} from 'pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled';
+
+/**
+ * 가게 정보 설정 탭
+ */
+export const ShopInfoTab: React.FC = () => {
+  return (
+    <Wrap>
+      <ContentWrap>
+        <ListItem>
+          <Label label='Wi-Fi 등록'>
+            <CurrentWifiBtn>현재 연결된 Wi-Fi 등록하기</CurrentWifiBtn>
+          </Label>
+        </ListItem>
+        <ListItem>
+          <Input
+            label='가게 이름'
+            placeholder='가게명을 작성해주세요. (ex. 캐치카페 한양대점)'
+          />
+        </ListItem>
+        <ListItem>
+          <Input
+            label='한 줄 소개'
+            placeholder='가게의 소개글을 작성해주세요. (최대 N자 이내)'
+          />
+        </ListItem>
+        <ListItem>
+          <Input label='가게 위치' placeholder='가게 주소 찾기' />
+        </ListItem>
+        <ListItem>
+          <Input label='가게 위치' placeholder='가게 주소 찾기' />
+        </ListItem>
+        <ListItem>
+          <Input label='가게 위치' placeholder='가게 주소 찾기' />
+        </ListItem>
+        <ListItem>
+          <Label label='가게 유형' required={false} />
+        </ListItem>
+        <ListItem>
+          <Label label='가게 유형' required={false} />
+        </ListItem>
+        <ListItem>
+          <Label label='가게 유형' required={false} />
+        </ListItem>
+        <ListItem>
+          <Label label='가게 유형' required={false} />
+        </ListItem>
+        <ListItem>
+          <Label label='가게 유형' required={false} />
+        </ListItem>
+        <RadioRow>
+          <Radio
+            id='restaurant'
+            label='음식점'
+            value='음식점'
+            name='shopSort'
+          />
+          <Radio id='cafe' label='카페' value='카페' name='shopSort' />
+          <Radio id='cafe' label='모임' value='모임' name='shopSort' />
+          <Radio id='etc' label='기타' value='기타' name='shopSort' />
+        </RadioRow>
+      </ContentWrap>
+    </Wrap>
+  );
+};

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
@@ -37,24 +37,6 @@ export const ShopInfoTab: React.FC = () => {
           <Input label='가게 위치' placeholder='가게 주소 찾기' />
         </ListItem>
         <ListItem>
-          <Input label='가게 위치' placeholder='가게 주소 찾기' />
-        </ListItem>
-        <ListItem>
-          <Input label='가게 위치' placeholder='가게 주소 찾기' />
-        </ListItem>
-        <ListItem>
-          <Label label='가게 유형' required={false} />
-        </ListItem>
-        <ListItem>
-          <Label label='가게 유형' required={false} />
-        </ListItem>
-        <ListItem>
-          <Label label='가게 유형' required={false} />
-        </ListItem>
-        <ListItem>
-          <Label label='가게 유형' required={false} />
-        </ListItem>
-        <ListItem>
           <Label label='가게 유형' required={false} />
         </ListItem>
         <RadioRow>

--- a/src/pages/ShopSettingPage/index.tsx
+++ b/src/pages/ShopSettingPage/index.tsx
@@ -1,6 +1,51 @@
+import type { TabItem } from 'components/Tabs.tsx';
+import { Button } from 'components/Button';
+import { Tabs } from 'components/Tabs.tsx';
+import { BusinessHourTab } from 'pages/ShopSettingPage/components/BusinessHourTab';
+import { EmployerTab } from 'pages/ShopSettingPage/components/EmployerTab';
+import { SettingSideBar } from 'pages/ShopSettingPage/components/SettingSideBar';
+import { ShopInfoTab } from 'pages/ShopSettingPage/components/ShopInfoTab';
+import { ContentWrap, HeaderWrap, Wrap } from 'pages/ShopSettingPage/styled';
+
+const tabList: TabItem[] = [
+  {
+    label: '가게 정보 설정',
+    content: <ShopInfoTab />,
+  },
+  {
+    label: '운영 시간 설정',
+    content: <BusinessHourTab />,
+  },
+  {
+    label: '직원 권한 설정',
+    content: <EmployerTab />,
+  },
+];
 /**
- * 컴포넌트
+ * 가게 설정 페이지
  */
 export const ShopSettingPage: React.FC = () => {
-  return <div>ShopSettingPage</div>;
+  return (
+    <Wrap>
+      <SettingSideBar />
+      <ContentWrap>
+        <HeaderWrap>
+          <Tabs tabList={tabList} tabWidth='63rem' />
+          <Button
+            width='7.6rem'
+            height='3.6rem'
+            borderRadius='0.6rem'
+            type='button'
+            style={{
+              position: 'absolute',
+              marginLeft: 'auto',
+              right: 0,
+            }}
+          >
+            저장
+          </Button>
+        </HeaderWrap>
+      </ContentWrap>
+    </Wrap>
+  );
 };

--- a/src/pages/ShopSettingPage/styled.ts
+++ b/src/pages/ShopSettingPage/styled.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components/macro';
+
+export const Wrap = styled.div`
+  flex: 1; // side bar 제외 남은 영역 꽉 채우기
+  /* min-height: 100vh; */
+  overflow: auto; // 필요
+  display: flex;
+`;
+export const HeaderWrap = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+export const ContentWrap = styled.div`
+  padding-top: 8.9rem;
+  padding-right: 9.6rem;
+  flex: 1;
+`;


### PR DESCRIPTION
## 기획 및 구현한 내용

가게 설정 페이지 사이드바 & 헤더 퍼블리싱
<!-- 구현한 기능에 관련된 기획을 서술 -->
<img width="800px" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/9324e3e0-a846-462f-8594-79250df7e488">

둘다 아직 미흡한 부분이 있는데 '직원 권한 설정' 페이지 퍼블리싱할 수 있는 상태로만 만들고 올립니다


## 변경사항

<!-- 주요 변경점 서술 -->

## 테스트 방법

yarn start 로 실행, 'http://localhost:3000/setting' 에서 확인
<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)

<img width="363" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/183a396b-f7b7-4bf8-a935-aff4da34c597">

각 탭마다 폴더 만들어놨어요.   
우영님은 `src/pages/ShopSettingPage/components/EmployerTab` 에서 작업하시면 '직원 권한 설정' 탭에서 내용물이 보일 거에요!
<img width="1079" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/19d696d6-36f8-459f-b97b-c87650eddcc0">


가게 정보 설정에 내용물 조금 만들어놨습니다 참고하세요
(`src/pages/ShopSettingPage/components/ShopInfoTab`)
<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [ ] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [ ] 이슈 상태를 업데이트 함.
