### PR TITLE
[Feature/#6] 가게 형태 높이 조절 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.45.0-next.1",
     "react-grid-layout": "^1.3.4",
+    "react-hook-form": "^7.45.0-next.1",
     "react-resizable": "^3.0.5",
     "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@types/react-grid-layout": "^1.3.2",
+    "@types/react-resizable": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
     "eslint": "^8.2.0",

--- a/src/assets/icons/alert-circle-border.svg
+++ b/src/assets/icons/alert-circle-border.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2.4rem" height="2.4rem" viewBox="0 0 24 24" fill="none">
+  <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12.0078 16L12.0078 12" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12.0078 8L11.9978 8" stroke="#1A1C2D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/alert-circle.svg
+++ b/src/assets/icons/alert-circle.svg
@@ -1,5 +1,6 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="1.6rem" height="1.6rem" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M8.00065 14.6663C11.6825 14.6663 14.6673 11.6816 14.6673 7.99967C14.6673 4.31778 11.6825 1.33301 8.00065 1.33301C4.31875 1.33301 1.33398 4.31778 1.33398 7.99967C1.33398 11.6816 4.31875 14.6663 8.00065 14.6663Z" fill="#FF8D4E"/>
 <path d="M8.00586 10.667L8.00586 8.00033" stroke="#F7F8FA" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8.00586 5.33301L7.99878 5.33301" stroke="#F7F8FA" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
+

--- a/src/common/hooks/useTab.ts
+++ b/src/common/hooks/useTab.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react';
+
+interface Return {
+  activeTab: number;
+  changeTab: (index: number) => void;
+}
+
+export const useTab = (): Return => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const changeTab = useCallback((index: number) => {
+    setActiveTab(index);
+  }, []);
+
+  return { activeTab, changeTab };
+};

--- a/src/components/Tabs.tsx/components/TabNavItem.styled.ts
+++ b/src/components/Tabs.tsx/components/TabNavItem.styled.ts
@@ -1,18 +1,19 @@
 import styled, { css } from 'styled-components';
 
-export const ListItem = styled.li`
+export const ListItem = styled.li<{
+  active?: boolean;
+  $isClickable: boolean;
+}>`
   flex: 1;
-`;
 
-export const Button = styled.button<{ active?: boolean }>`
-  width: 100%;
-  height: 100%;
-
-  /* background-color: aqua; */
-
-  &:active {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
+  ${({ $isClickable }) =>
+    $isClickable &&
+    css`
+      cursor: pointer;
+      &:active {
+        background-color: rgba(0, 0, 0, 0.05);
+      }
+    `}
 `;
 
 export const Text = styled.p<{ active?: boolean }>`

--- a/src/components/Tabs.tsx/components/TabNavItem.tsx
+++ b/src/components/Tabs.tsx/components/TabNavItem.tsx
@@ -1,6 +1,5 @@
 import type { HTMLAttributes } from 'react';
 import {
-  Button,
   ListItem,
   Text,
 } from 'components/Tabs.tsx/components/TabNavItem.styled';
@@ -9,6 +8,7 @@ interface TabNavItemProps extends HTMLAttributes<HTMLLIElement> {
   text: string;
   index: number;
   activeTab: number;
+  isClickable: boolean;
 }
 
 /**
@@ -18,13 +18,12 @@ export const TabNavItem: React.FC<TabNavItemProps> = ({
   text,
   index,
   activeTab,
+  isClickable,
   ...rest
 }) => {
   return (
-    <ListItem {...rest}>
-      <Button type='button'>
-        <Text active={activeTab === index}>{text}</Text>
-      </Button>
+    <ListItem {...rest} $isClickable={isClickable}>
+      <Text active={activeTab === index}>{text}</Text>
     </ListItem>
   );
 };

--- a/src/components/Tabs.tsx/index.tsx
+++ b/src/components/Tabs.tsx/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import styled from 'styled-components/macro';
 import type React from 'react';
 import { TabNavItem } from 'components/Tabs.tsx/components/TabNavItem';
@@ -11,18 +10,20 @@ export interface TabItem {
 interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
   tabList: TabItem[];
   tabWidth?: string;
+  activeTab: number;
+  onClickTab?: (index: number) => void;
 }
 
 /**
  * 탭 메뉴 컴포넌트
  */
-export const Tabs: React.FC<TabsProps> = ({ tabList, tabWidth, ...rest }) => {
-  const [activeTab, setActiveTab] = useState(0);
-
-  const onClickItem = (index: number) => {
-    setActiveTab(index);
-  };
-
+export const Tabs: React.FC<TabsProps> = ({
+  tabList,
+  tabWidth,
+  activeTab,
+  onClickTab,
+  ...rest
+}) => {
   const tabNavItemList = tabList.map(
     (item, index): React.ReactElement => (
       <TabNavItem
@@ -30,7 +31,8 @@ export const Tabs: React.FC<TabsProps> = ({ tabList, tabWidth, ...rest }) => {
         index={index}
         text={item.label}
         activeTab={activeTab}
-        onClick={() => onClickItem(index)}
+        isClickable={!!onClickTab}
+        {...(onClickTab && { onClick: () => onClickTab(index) })}
       />
     ),
   );
@@ -38,7 +40,11 @@ export const Tabs: React.FC<TabsProps> = ({ tabList, tabWidth, ...rest }) => {
   return (
     <Wrap {...rest}>
       <TabWrap>{tabNavItemList}</TabWrap>
-      <ContentWrap>{tabList[activeTab].content}</ContentWrap>
+      {tabList.map((item, index) => (
+        <ContentWrap hidden={activeTab !== index} key={item.label}>
+          {item.content}
+        </ContentWrap>
+      ))}
     </Wrap>
   );
 };

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -55,13 +55,15 @@ export const RightWrap = styled.div`
   flex-direction: column;
 `;
 
-export const ResizableWrap = styled(ResizableBox)`
+export const ResizableWrap = styled(ResizableBox)<{ $width?: number }>`
   background-color: white;
 
   border-bottom: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-left: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-right: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-radius: 0 0 1.2rem 1.2rem;
+
+  width: ${({ $width }) => $width && $width + 'px'};
 `;
 
 export const ShopGridBackground = styled(GridLayout)<{

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -63,13 +63,13 @@ export const ResizableWrap = styled(ResizableBox)<{
   width: ${({ $width }) => $width && $width + 'px'};
 
   box-sizing: content-box;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-top: 4px;
+  padding-bottom: 4px;
 
-  border-bottom: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
-  border-left: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
-  border-right: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
-  border-radius: 0 0 1.2rem 1.2rem;
+  border-bottom: 2px solid ${({ theme }) => theme.palette.grey[200]};
+  border-left: 2px solid ${({ theme }) => theme.palette.grey[200]};
+  border-right: 2px solid ${({ theme }) => theme.palette.grey[200]};
+  border-radius: 0 0 12px 12px;
 `;
 
 export const ShopGridBackground = styled(GridLayout)<{

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -81,14 +81,14 @@ export const GridWrap = styled.div`
   background-color: skyblue;
 `;
 
-export const GridTable = styled.div`
+export const GridTable = styled.div<{ isClickable: boolean }>`
   background-color: ${(props): string => props.theme.palette.grey[100]};
 
   border-color: ${({ theme }) => theme.palette.black.main};
   border-width: 1px;
   border-style: solid;
 
-  cursor: pointer;
+  cursor: ${({ isClickable }) => (isClickable ? 'pointer' : 'default')};
 `;
 
 // 의자 바깥에 투명한 테두리를 넣기 위함
@@ -97,7 +97,7 @@ export const ChairBorder = styled.div`
 `;
 
 // 검정 테두리를 준 의자 영역
-export const Chair = styled.div`
+export const Chair = styled.div<{ isClickable: boolean }>`
   background-color: ${(props): string => props.theme.palette.grey[100]};
 
   width: ${CHAIR_SIZE_PX - CHAIR_BORDER_PX}px;
@@ -106,5 +106,5 @@ export const Chair = styled.div`
   border: ${CHAIR_BORDER_PX}px solid ${({ theme }) => theme.palette.black.main};
   border-radius: 50%;
 
-  cursor: pointer;
+  cursor: ${({ isClickable }) => (isClickable ? 'pointer' : 'default')};
 `;

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -1,5 +1,7 @@
 import GridLayout from 'react-grid-layout';
+import { ResizableBox } from 'react-resizable';
 import styled from 'styled-components/macro';
+import chevronDown from 'assets/icons/chevron-down.svg';
 import { SideBar } from 'components/SideBar';
 import {
   CHAIR_BORDER_PX,
@@ -12,10 +14,32 @@ export const Wrap = styled.div`
   display: flex;
   background-color: ${({ theme }) => theme.palette.grey[100]};
 
-  // resizable 영역 범위 바꾸는 부분
+  // 그리드 아이템의 resizable 영역 좁힘
   .react-grid-item > .react-resizable-handle {
     width: 1rem;
     height: 1rem;
+  }
+
+  // 가게 형태 resizable 마우스 커스텀
+  .react-resizable > .react-resizable-handle.react-resizable-handle-s {
+    transform: rotate(0);
+    bottom: -5px;
+    width: 100%;
+    left: 0;
+    margin-left: 0;
+    background-image: none;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      width: 3rem;
+      height: 3rem;
+      background-color: ${({ theme }) => theme.palette.grey[300]};
+      mask-image: url(${chevronDown});
+      mask-position: center;
+      mask-size: contain;
+    }
   }
 `;
 
@@ -31,22 +55,24 @@ export const RightWrap = styled.div`
   flex-direction: column;
 `;
 
-export const ShopGridBackground = styled(GridLayout)<{
-  width: number;
-  $height: number;
-}>`
-  width: ${({ width }) => {
-    return width + 'px';
-  }};
-
-  height: 500px;
-
+export const ResizableWrap = styled(ResizableBox)`
   background-color: white;
 
   border-bottom: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-left: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-right: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-radius: 0 0 1.2rem 1.2rem;
+`;
+
+export const ShopGridBackground = styled(GridLayout)<{
+  width: number;
+  $height?: number;
+}>`
+  width: ${({ width }) => {
+    return width + 'px';
+  }};
+
+  height: ${({ $height }) => $height + 'px'};
 `;
 
 export const GridWrap = styled.div`
@@ -64,7 +90,9 @@ export const GridTable = styled.div`
 `;
 
 // 의자 바깥에 투명한 테두리를 넣기 위함
-export const ChairBorder = styled.div``;
+export const ChairBorder = styled.div`
+  ${flexSet()}
+`;
 
 // 검정 테두리를 준 의자 영역
 export const Chair = styled.div`

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -49,7 +49,7 @@ export const StyledSideBar = styled(SideBar)`
 `;
 
 export const RightWrap = styled.div`
-  /* background-color: aqua; */
+  padding: 3rem 1.5rem;
 
   margin: auto;
   flex-direction: column;

--- a/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
+++ b/src/pages/LayoutSettingPage/LayoutSettingPage.styled.ts
@@ -55,15 +55,21 @@ export const RightWrap = styled.div`
   flex-direction: column;
 `;
 
-export const ResizableWrap = styled(ResizableBox)<{ $width?: number }>`
+export const ResizableWrap = styled(ResizableBox)<{
+  $width?: number;
+}>`
   background-color: white;
+
+  width: ${({ $width }) => $width && $width + 'px'};
+
+  box-sizing: content-box;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 
   border-bottom: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-left: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-right: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
   border-radius: 0 0 1.2rem 1.2rem;
-
-  width: ${({ $width }) => $width && $width + 'px'};
 `;
 
 export const ShopGridBackground = styled(GridLayout)<{

--- a/src/pages/LayoutSettingPage/components/SeatArrangementTab/index.tsx
+++ b/src/pages/LayoutSettingPage/components/SeatArrangementTab/index.tsx
@@ -17,14 +17,25 @@ import {
 import { Chair } from 'pages/LayoutSettingPage/components/SeatArrangementTab/components/Chair';
 import { Table } from 'pages/LayoutSettingPage/components/SeatArrangementTab/components/Table';
 
+interface SeatArrangementTabProps {
+  changeTab: (index: number) => void;
+}
+
 /**
  * '좌석 설정' > '좌석 배치' 탭 클릭했을 때 보여줄 컴포넌트
  */
-export const SeatArrangementTab: React.FC = () => {
+export const SeatArrangementTab: React.FC<SeatArrangementTabProps> = ({
+  changeTab,
+}) => {
   const theme = useTheme();
 
   const handleSave = () => {
+    // TODO api 호출
     // ShopApi.saveShopLayout(1);
+  };
+
+  const handleChangePreviousTab = () => {
+    changeTab(0);
   };
   return (
     <Wrap>
@@ -72,7 +83,7 @@ export const SeatArrangementTab: React.FC = () => {
 
       <ButtonRow>
         <StyledButton
-          onClick={handleSave}
+          onClick={handleChangePreviousTab}
           backgroundColor={theme.palette.grey[100]}
           color={theme.palette.grey[400]}
         >

--- a/src/pages/LayoutSettingPage/components/ShopFormTab/ShopFormTab.styled.ts
+++ b/src/pages/LayoutSettingPage/components/ShopFormTab/ShopFormTab.styled.ts
@@ -35,16 +35,20 @@ export const Label = styled.label`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  cursor: pointer;
 `;
 
 const SQUARE_HEIGHT = 10;
 
-export const Square = styled.div`
+export const Square = styled.div<{ $isChecked: boolean }>`
   margin-bottom: 1rem;
   width: 10rem;
   height: ${SQUARE_HEIGHT}rem;
 
-  border: 0.2rem solid ${({ theme }) => theme.palette.grey[200]};
+  border: 0.2rem solid
+    ${({ $isChecked, theme }) =>
+      $isChecked ? theme.palette.primary.orange : theme.palette.grey[200]};
   border-radius: 0.4rem;
 
   background-color: ${({ theme }) => theme.palette.grey[50]};
@@ -97,9 +101,14 @@ export const HeightInput = styled.input`
   font-weight: 500;
   text-align: center;
   color: ${({ theme }) => theme.palette.grey[500]};
+
+  &:focus {
+    border: 1px solid ${({ theme }) => theme.palette.primary.orange};
+  }
 `;
 
 export const IconWrap = styled.div`
+  cursor: pointer;
   &:hover {
     svg {
       rect {

--- a/src/pages/LayoutSettingPage/components/ShopFormTab/components/CheckRadioButton.tsx
+++ b/src/pages/LayoutSettingPage/components/ShopFormTab/components/CheckRadioButton.tsx
@@ -5,8 +5,8 @@ import type { Ref } from 'react';
 import checkIcon from 'assets/icons/check.svg';
 import checkedIcon from 'assets/icons/checked.svg';
 
-interface RadioProps extends React.HtmlHTMLAttributes<HTMLInputElement> {
-  id: string;
+interface RadioProps extends React.ComponentPropsWithRef<'input'> {
+  id?: string;
   name: string; // radio group 내에서 동일한 이름 사용해야함
   value: string;
 }
@@ -20,11 +20,11 @@ export const CheckRadioButton = forwardRef(
       <>
         <RadioInput
           type='radio'
-          id={id}
           name={name}
           value={value}
           ref={ref}
           {...rest}
+          {...{ id }}
         />
         <div className='radioBtnIcon'>라디오 버튼</div>
       </>

--- a/src/pages/LayoutSettingPage/components/ShopFormTab/index.tsx
+++ b/src/pages/LayoutSettingPage/components/ShopFormTab/index.tsx
@@ -37,6 +37,7 @@ type CheckState = 'SQUARE' | 'RECTANGLE' | 'NONE';
 
 interface ShopFormTabProps {
   rowCnt: number;
+  minRowCnt: number;
   changeRowCnt: (value: number | ChangeRowCommand) => void;
   changeTab: (index: number) => void;
 }
@@ -45,6 +46,7 @@ interface ShopFormTabProps {
  */
 export const ShopFormTab: React.FC<ShopFormTabProps> = ({
   rowCnt,
+  minRowCnt,
   changeRowCnt,
   changeTab,
 }) => {
@@ -78,7 +80,17 @@ export const ShopFormTab: React.FC<ShopFormTabProps> = ({
   };
 
   const handleRoundInput = () => {
-    setHeightInput((prev) => nearestDivisible(prev));
+    // TODO: 리팩토링
+    const minHeight = minRowCnt * TABLE_SIZE_PX;
+    if (heightInput < minHeight) {
+      setHeightInput(minHeight);
+      changeRowCnt(minRowCnt);
+      return;
+    }
+
+    const nearestHeight = nearestDivisible(heightInput);
+    setHeightInput(nearestHeight);
+    changeRowCnt(nearestHeight / TABLE_SIZE_PX);
   };
 
   const handleChangeNextTab = () => {

--- a/src/pages/LayoutSettingPage/components/ShopFormTab/index.tsx
+++ b/src/pages/LayoutSettingPage/components/ShopFormTab/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ChangeRowCommand } from 'pages/LayoutSettingPage/hooks/useShopHeight';
+import type { ShopFormState } from 'pages/LayoutSettingPage/utils/types';
 import { ReactComponent as ChevronLeftCircle } from 'assets/icons/chevron-left-circle.svg';
 import { ReactComponent as CheveronRightCircle } from 'assets/icons/chevron-right-circle.svg';
 import {
@@ -33,13 +34,13 @@ function nearestDivisible(n: number): number {
   return n + (divisor - remainder);
 }
 
-type CheckState = 'SQUARE' | 'RECTANGLE' | 'NONE';
-
 interface ShopFormTabProps {
   rowCnt: number;
   minRowCnt: number;
   changeRowCnt: (value: number | ChangeRowCommand) => void;
   changeTab: (index: number) => void;
+  shopFormState: ShopFormState;
+  setShopFormState: React.Dispatch<React.SetStateAction<ShopFormState>>;
 }
 /**
  * '좌석 설정' > '가게 형태' 탭 클릭했을 때 보여줄 컴포넌트
@@ -49,8 +50,9 @@ export const ShopFormTab: React.FC<ShopFormTabProps> = ({
   minRowCnt,
   changeRowCnt,
   changeTab,
+  shopFormState: checkState,
+  setShopFormState: setCheckState,
 }) => {
-  const [checkState, setCheckState] = useState<CheckState>('NONE');
   const [heightInput, setHeightInput] = useState(rowCnt * TABLE_SIZE_PX);
 
   const handleResizeUpDown = (command: ChangeRowCommand) => {

--- a/src/pages/LayoutSettingPage/components/Space.tsx
+++ b/src/pages/LayoutSettingPage/components/Space.tsx
@@ -84,11 +84,15 @@ export const DeleteWrap = styled.div`
   top: 0.4rem;
   right: 0.4rem;
 
-  :hover {
-    path {
-      // todo 순권님 (마우스 올렸을 때 디자인)
-      stroke-width: 4;
-      /* stroke: black; */
-    }
+  :hover::after {
+    display: inline-block;
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 2.4rem;
+    height: 2.4rem;
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 20%;
   }
 `;

--- a/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
@@ -24,26 +24,46 @@ export const BoldText = styled.span`
 export const SpaceWrap = styled.div`
   display: flex;
 
-  padding: 2rem;
+  /* padding: 2rem 0rem 0 2rem; */
   width: ${TABLE_SIZE_PX * COLUMN_CNT + 'px'};
-  height: 13.1rem;
   background-color: ${({ theme }) => theme.palette.primary.dark};
   border-radius: 1.2rem 1.2rem 0 0;
 
-  border-top: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
-  border-left: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
-  border-right: 0.3rem solid ${({ theme }) => theme.palette.grey[200]};
+  // TODO 바깥 테두리 (순권)
+  /* outline-style: solid;
+  outline-color: ${({ theme }) => theme.palette.grey[200]};
+  outline-width: 0.3rem 0.3rem 0 0.3rem; */
 
-  overflow-x: auto;
+  // 내부 테두리
+  border-color: ${({ theme }) => theme.palette.primary.dark};
+  border-style: solid;
+  border-width: 2rem 0rem 0.6rem 2rem;
 
-  // 스크롤바 숨기기
-  /* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
-  &::-webkit-scrollbar {
-    display: none;
+  padding-bottom: 0.6rem;
+
+  overflow-x: scroll;
+
+  ::-webkit-scrollbar {
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    border: 0.5px solid var(--grey-300, #a9abb6);
+    background: rgba(255, 255, 255, 0.1);
   }
 
-  & {
-    scrollbar-width: none; /* 파이어폭스 */
+  &::after {
+    content: '';
+    position: sticky;
+    right: 0;
+    width: 4.4rem;
+    height: 9.1rem;
+    opacity: 0.5;
+    background: linear-gradient(270deg, #303030 0%, rgba(48, 48, 48, 0) 100%);
+    pointer-events: none; // 클릭 무시
   }
 `;
 

--- a/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
@@ -25,7 +25,7 @@ export const SpaceWrap = styled.div`
   display: flex;
 
   /* padding: 2rem 0rem 0 2rem; */
-  width: ${TABLE_SIZE_PX * COLUMN_CNT + 'px'};
+  width: ${TABLE_SIZE_PX * COLUMN_CNT + 4 + 'px'};
   background-color: ${({ theme }) => theme.palette.primary.dark};
   border-radius: 1.2rem 1.2rem 0 0;
 

--- a/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.styled.ts
@@ -4,7 +4,24 @@ import {
   TABLE_SIZE_PX,
 } from 'pages/LayoutSettingPage/utils/constants';
 
-export const Wrap = styled.div`
+export const InfoWrap = styled.div`
+  display: flex;
+  align-items: center;
+
+  margin-bottom: 0.8rem;
+
+  font-size: 1.6rem;
+  font-weight: 400;
+  background-color: ${({ theme }) => theme.palette.black};
+`;
+
+export const BoldText = styled.span`
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin: 0 0.8rem 0 0.4rem;
+`;
+
+export const SpaceWrap = styled.div`
   display: flex;
 
   padding: 2rem;

--- a/src/pages/LayoutSettingPage/components/SpaceRow.tsx
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.tsx
@@ -1,10 +1,13 @@
+import { ReactComponent as AlertCircleBorderIcon } from 'assets/icons/alert-circle-border.svg';
 import { ReactComponent as PlusCircle } from 'assets/icons/plus-circle.svg';
 
 import { Space } from 'pages/LayoutSettingPage/components/Space';
 import {
   AddRow,
   AddText,
-  Wrap,
+  BoldText,
+  InfoWrap,
+  SpaceWrap,
 } from 'pages/LayoutSettingPage/components/SpaceRow.styled';
 import { useSpace } from 'pages/LayoutSettingPage/hooks/useSpace';
 
@@ -16,21 +19,27 @@ export const SpaceRow: React.FC = () => {
     useSpace();
 
   return (
-    <Wrap>
-      {spaceList.map((space) => (
-        <Space
-          key={space.storeSpaceId}
-          id={space.storeSpaceId}
-          name={space.name}
-          onClick={setSelectedSpace}
-          isSelected={space.storeSpaceId === selected}
-          deleteSpace={deleteSpace}
-        />
-      ))}
-      <AddRow onClick={addSpace}>
-        <PlusCircle stroke='white' />
-        <AddText>스페이스 추가</AddText>
-      </AddRow>
-    </Wrap>
+    <>
+      <InfoWrap>
+        <AlertCircleBorderIcon />
+        <BoldText>스페이스란?</BoldText> 가게의 방이나 분리된 공간을 의미해요.
+      </InfoWrap>
+      <SpaceWrap>
+        {spaceList.map((space) => (
+          <Space
+            key={space.storeSpaceId}
+            id={space.storeSpaceId}
+            name={space.name}
+            onClick={setSelectedSpace}
+            isSelected={space.storeSpaceId === selected}
+            deleteSpace={deleteSpace}
+          />
+        ))}
+        <AddRow onClick={addSpace}>
+          <PlusCircle stroke='white' />
+          <AddText>스페이스 추가</AddText>
+        </AddRow>
+      </SpaceWrap>
+    </>
   );
 };

--- a/src/pages/LayoutSettingPage/components/SpaceRow.tsx
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import type { SpaceType } from 'pages/LayoutSettingPage/utils/types';
 import { ReactComponent as PlusCircle } from 'assets/icons/plus-circle.svg';
 
 import { Space } from 'pages/LayoutSettingPage/components/Space';
@@ -8,29 +6,14 @@ import {
   AddText,
   Wrap,
 } from 'pages/LayoutSettingPage/components/SpaceRow.styled';
-
-interface SpaceRowProps {
-  spaceList: SpaceType[];
-  addSpace: () => void;
-  deleteSpace: (id: number) => void;
-}
+import { useSpace } from 'pages/LayoutSettingPage/hooks/useSpace';
 
 /**
  * space 목록 컴포넌트 (검은색 영역)
  */
-export const SpaceRow: React.FC<SpaceRowProps> = ({
-  spaceList,
-  addSpace,
-  deleteSpace,
-}) => {
-  const [selected, setSelected] = useState(spaceList[0]?.storeSpaceId ?? 1);
-  const handleClickSpace = (id: number) => {
-    setSelected(id);
-  };
-
-  const handleAddSpace = () => {
-    addSpace();
-  };
+export const SpaceRow: React.FC = () => {
+  const { spaceList, addSpace, deleteSpace, selected, setSelectedSpace } =
+    useSpace();
 
   return (
     <Wrap>
@@ -39,12 +22,12 @@ export const SpaceRow: React.FC<SpaceRowProps> = ({
           key={space.storeSpaceId}
           id={space.storeSpaceId}
           name={space.name}
-          onClick={handleClickSpace}
+          onClick={setSelectedSpace}
           isSelected={space.storeSpaceId === selected}
           deleteSpace={deleteSpace}
         />
       ))}
-      <AddRow onClick={handleAddSpace}>
+      <AddRow onClick={addSpace}>
         <PlusCircle stroke='white' />
         <AddText>스페이스 추가</AddText>
       </AddRow>

--- a/src/pages/LayoutSettingPage/hooks/useShopHeight.ts
+++ b/src/pages/LayoutSettingPage/hooks/useShopHeight.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import type { MyLayout } from 'pages/LayoutSettingPage';
+
+export type ChangeRowCommand = 'UP' | 'DOWN';
+
+interface Return {
+  rowCnt: number;
+  maxHeight: number;
+  changeRowCnt: (value: number | ChangeRowCommand) => void;
+  changeMaxHeight: (height: number) => void;
+  findMaxHeight: (layouts: MyLayout[]) => number;
+}
+
+export const useShopHeight = (defaultRowCnt: number): Return => {
+  const [rowCnt, setRowCnt] = useState(defaultRowCnt);
+  const [maxHeight, setMaxHeight] = useState(0);
+
+  const changeRowCnt = (value: number | ChangeRowCommand) => {
+    if (value === 'UP') {
+      setRowCnt((prev) => prev + 1);
+      return;
+    }
+    if (value === 'DOWN') {
+      setRowCnt((prev) => prev - 1);
+      return;
+    }
+    setRowCnt(value);
+  };
+
+  const changeMaxHeight = (height: number) => {
+    setMaxHeight(height);
+  };
+
+  const findMaxHeight = (layouts: MyLayout[]) => {
+    let max = 0;
+    layouts.forEach((layout) => {
+      if (layout.y + layout.h <= max) {
+        return;
+      }
+      max = layout.y + layout.h;
+    });
+    return max;
+  };
+
+  return { rowCnt, maxHeight, changeRowCnt, changeMaxHeight, findMaxHeight };
+};

--- a/src/pages/LayoutSettingPage/hooks/useShopHeight.ts
+++ b/src/pages/LayoutSettingPage/hooks/useShopHeight.ts
@@ -5,33 +5,36 @@ export type ChangeRowCommand = 'UP' | 'DOWN';
 
 interface Return {
   rowCnt: number;
-  maxHeight: number;
+  minRowCnt: number;
   changeRowCnt: (value: number | ChangeRowCommand) => void;
-  changeMaxHeight: (height: number) => void;
-  findMaxHeight: (layouts: MyLayout[]) => number;
+  changeMinRowCnt: (height: number) => void;
+  findMinRowCnt: (layouts: MyLayout[]) => number;
 }
 
 export const useShopHeight = (defaultRowCnt: number): Return => {
   const [rowCnt, setRowCnt] = useState(defaultRowCnt);
-  const [maxHeight, setMaxHeight] = useState(0);
+  const [minRowCnt, setMinRowCnt] = useState(0);
+
+  const getValidRowCnt = (newRowCnt: number) =>
+    newRowCnt < minRowCnt ? minRowCnt : newRowCnt;
 
   const changeRowCnt = (value: number | ChangeRowCommand) => {
     if (value === 'UP') {
-      setRowCnt((prev) => prev + 1);
+      setRowCnt((prev) => getValidRowCnt(prev + 1));
       return;
     }
     if (value === 'DOWN') {
-      setRowCnt((prev) => prev - 1);
+      setRowCnt((prev) => getValidRowCnt(prev - 1));
       return;
     }
-    setRowCnt(value);
+    setRowCnt(getValidRowCnt(value));
   };
 
-  const changeMaxHeight = (height: number) => {
-    setMaxHeight(height);
+  const changeMinRowCnt = (height: number) => {
+    setMinRowCnt(height);
   };
 
-  const findMaxHeight = (layouts: MyLayout[]) => {
+  const findMinRowCnt = (layouts: MyLayout[]) => {
     let max = 0;
     layouts.forEach((layout) => {
       if (layout.y + layout.h <= max) {
@@ -42,5 +45,11 @@ export const useShopHeight = (defaultRowCnt: number): Return => {
     return max;
   };
 
-  return { rowCnt, maxHeight, changeRowCnt, changeMaxHeight, findMaxHeight };
+  return {
+    rowCnt,
+    minRowCnt,
+    changeRowCnt,
+    changeMinRowCnt,
+    findMinRowCnt,
+  };
 };

--- a/src/pages/LayoutSettingPage/hooks/useSpace.ts
+++ b/src/pages/LayoutSettingPage/hooks/useSpace.ts
@@ -1,0 +1,51 @@
+import { useCallback, useState } from 'react';
+import type { SpaceType } from 'pages/LayoutSettingPage/utils/types';
+
+interface Return {
+  spaceList: SpaceType[];
+  setSpaces: (space: SpaceType[]) => void;
+  addSpace: () => void;
+  deleteSpace: (id: number) => void;
+  setSelectedSpace: (id: number) => void;
+  selected: number;
+}
+
+export const useSpace = (): Return => {
+  const [spaceList, setSpaceList] = useState<SpaceType[]>([]);
+  const [selected, setSelected] = useState(spaceList?.[0]?.storeSpaceId);
+
+  const setSelectedSpace = (id: number) => {
+    setSelected(id);
+  };
+
+  const setSpaces = useCallback((space: SpaceType[]) => {
+    setSpaceList(space);
+  }, []);
+
+  const addSpace = useCallback(() => {
+    const newSpace: SpaceType = {
+      storeSpaceId: Date.now(),
+      name: 'Space',
+    };
+    setSpaceList([...spaceList, newSpace]);
+  }, [spaceList]);
+
+  const deleteSpace = useCallback(
+    (id: number) => {
+      const deleted = spaceList.filter(
+        ({ storeSpaceId }) => storeSpaceId !== id,
+      );
+      setSpaceList(deleted);
+    },
+    [spaceList],
+  );
+
+  return {
+    spaceList,
+    setSpaces,
+    addSpace,
+    deleteSpace,
+    selected,
+    setSelectedSpace,
+  };
+};

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -180,6 +180,7 @@ export const LayoutSettingPage: React.FC = () => {
               TABLE_SIZE_PX,
               minRowCnt * TABLE_SIZE_PX || TABLE_SIZE_PX * 2,
             ]}
+            maxConstraints={[1000, TABLE_SIZE_PX * COLUMN_CNT]}
             axis={undefined}
             onResize={handleResize}
           >

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -56,11 +56,11 @@ export const LayoutSettingPage: React.FC = () => {
     if (sort === 'chair') {
       return (
         <ChairBorder key={item.i} className='chair'>
-          <Chair />
+          <Chair isClickable={activeTab === 1} />
         </ChairBorder>
       );
     }
-    return <GridTable key={item.i} />;
+    return <GridTable key={item.i} isClickable={activeTab === 1} />;
   });
 
   const handleResize = (e: SyntheticEvent, data: ResizeCallbackData) => {

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -39,7 +39,7 @@ export interface MyLayout extends Layout {
 export const LayoutSettingPage: React.FC = () => {
   const { activeTab, changeTab } = useTab();
   const { setSpaces } = useSpace();
-  const { rowCnt, maxHeight, changeRowCnt, changeMaxHeight, findMaxHeight } =
+  const { rowCnt, minRowCnt, changeRowCnt, changeMinRowCnt, findMinRowCnt } =
     useShopHeight(DEFAULT_ROW_CNT);
   const { size } = useContext(DragContext);
 
@@ -99,8 +99,8 @@ export const LayoutSettingPage: React.FC = () => {
   };
 
   useEffect(() => {
-    changeMaxHeight(findMaxHeight(layouts));
-  }, [layouts, changeMaxHeight, findMaxHeight]);
+    changeMinRowCnt(findMinRowCnt(layouts));
+  }, [layouts, changeMinRowCnt, findMinRowCnt]);
 
   useEffect(() => {
     const spaces = shopList.map(({ storeSpaceId, name }) => ({
@@ -148,6 +148,7 @@ export const LayoutSettingPage: React.FC = () => {
                 <ShopFormTab
                   changeRowCnt={changeRowCnt}
                   rowCnt={rowCnt}
+                  minRowCnt={minRowCnt}
                   changeTab={changeTab}
                 />
               ),
@@ -171,7 +172,7 @@ export const LayoutSettingPage: React.FC = () => {
             }}
             minConstraints={[
               TABLE_SIZE_PX,
-              maxHeight * TABLE_SIZE_PX || TABLE_SIZE_PX * 2,
+              minRowCnt * TABLE_SIZE_PX || TABLE_SIZE_PX * 2,
             ]}
             axis={undefined}
             onResize={handleResize}

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -19,6 +19,7 @@ import 'react-resizable/css/styles.css';
 import 'react-grid-layout/css/styles.css';
 
 import { SpaceRow } from 'pages/LayoutSettingPage/components/SpaceRow';
+import { useSpace } from 'pages/LayoutSettingPage/hooks/useSpace';
 import { DragContext } from 'pages/LayoutSettingPage/utils/DragContext';
 import {
   COLUMN_CNT,
@@ -37,24 +38,12 @@ interface MyLayout extends Layout {
  * 좌석 설정 페이지
  */
 export const LayoutSettingPage: React.FC = () => {
+  const { setSpaces } = useSpace();
   const [shopList, setShopList] = useState([]);
   const [mylayout, setmyLayout] = useState<MyLayout[]>([]);
   const [spaceList, setSpaceList] = useState<SpaceType[]>([]);
 
   const { size } = useContext(DragContext);
-
-  const addSpace = () => {
-    const newSpace: SpaceType = {
-      storeSpaceId: Date.now(),
-      name: 'Space',
-    };
-    setSpaceList([...spaceList, newSpace]);
-  };
-
-  const deleteSpace = (id: number) => {
-    const deleted = spaceList.filter(({ storeSpaceId }) => storeSpaceId !== id);
-    setSpaceList(deleted);
-  };
 
   const itemsDom = mylayout.map((item) => {
     const sort = item.i.split('-')[0];
@@ -100,8 +89,8 @@ export const LayoutSettingPage: React.FC = () => {
       storeSpaceId,
       name,
     }));
-    setSpaceList(spaces);
-  }, [shopList]);
+    setSpaces(spaces);
+  }, [shopList, setSpaces]);
 
   return (
     <Wrap>
@@ -109,11 +98,7 @@ export const LayoutSettingPage: React.FC = () => {
         <Tabs tabList={tabList} />
       </StyledSideBar>
       <RightWrap>
-        <SpaceRow
-          spaceList={spaceList}
-          addSpace={addSpace}
-          deleteSpace={deleteSpace}
-        />
+        <SpaceRow />
         <ShopGridBackground
           layout={mylayout}
           rowHeight={TABLE_SIZE_PX}

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react';
+import type { ShopFormState } from 'pages/LayoutSettingPage/utils/types';
 import type { SyntheticEvent } from 'react';
 import type { Layout } from 'react-grid-layout';
 import type { ResizeCallbackData } from 'react-resizable';
@@ -16,10 +17,10 @@ import {
   ResizableWrap,
 } from 'pages/LayoutSettingPage/LayoutSettingPage.styled';
 import { SeatArrangementTab } from 'pages/LayoutSettingPage/components/SeatArrangementTab';
-import { ShopFormTab } from 'pages/LayoutSettingPage/components/ShopFormTab';
 import 'react-resizable/css/styles.css';
 import 'react-grid-layout/css/styles.css';
 
+import { ShopFormTab } from 'pages/LayoutSettingPage/components/ShopFormTab';
 import { SpaceRow } from 'pages/LayoutSettingPage/components/SpaceRow';
 import { useShopHeight } from 'pages/LayoutSettingPage/hooks/useShopHeight';
 import { useSpace } from 'pages/LayoutSettingPage/hooks/useSpace';
@@ -43,6 +44,8 @@ export const LayoutSettingPage: React.FC = () => {
     useShopHeight(DEFAULT_ROW_CNT);
   const { size } = useContext(DragContext);
 
+  const [shopFormState, setShopFormState] =
+    useState<ShopFormState>('RECTANGLE');
   const [shopList, setShopList] = useState([]);
   const [layouts, setLayouts] = useState<MyLayout[]>([]);
 
@@ -63,6 +66,7 @@ export const LayoutSettingPage: React.FC = () => {
   const handleResize = (e: SyntheticEvent, data: ResizeCallbackData) => {
     const { height } = data.size;
     changeRowCnt(height / TABLE_SIZE_PX);
+    setShopFormState('NONE');
   };
 
   const handleDropDragOver = () => {
@@ -150,6 +154,8 @@ export const LayoutSettingPage: React.FC = () => {
                   rowCnt={rowCnt}
                   minRowCnt={minRowCnt}
                   changeTab={changeTab}
+                  shopFormState={shopFormState}
+                  setShopFormState={setShopFormState}
                 />
               ),
             },

--- a/src/pages/LayoutSettingPage/index.tsx
+++ b/src/pages/LayoutSettingPage/index.tsx
@@ -206,7 +206,7 @@ export const LayoutSettingPage: React.FC = () => {
             </ShopGridBackground>
           </ResizableWrap>
         ) : (
-          <ResizableWrap as='div'>
+          <ResizableWrap as='div' $width={TABLE_SIZE_PX * COLUMN_CNT}>
             <ShopGridBackground
               layout={layouts}
               rowHeight={TABLE_SIZE_PX}

--- a/src/pages/LayoutSettingPage/utils/constants.ts
+++ b/src/pages/LayoutSettingPage/utils/constants.ts
@@ -4,3 +4,4 @@ export const CHAIR_BORDER_PX = 1;
 export const CHAIR_SIZE_PX = 20;
 
 export const COLUMN_CNT = 32;
+export const DEFAULT_ROW_CNT = 15;

--- a/src/pages/LayoutSettingPage/utils/types.ts
+++ b/src/pages/LayoutSettingPage/utils/types.ts
@@ -2,3 +2,5 @@ export interface SpaceType {
   storeSpaceId: number;
   name: string;
 }
+
+export type ShopFormState = 'SQUARE' | 'RECTANGLE' | 'NONE';

--- a/src/pages/ShopSettingPage/components/EmployerTab/EmployerTab.styled.ts
+++ b/src/pages/ShopSettingPage/components/EmployerTab/EmployerTab.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Circle from 'assets/icons/alertcircle.svg';
+import Circle from 'assets/icons/alert-circle.svg';
 import Search from 'assets/icons/search.svg';
 
 export const EmployerTabWrapper = styled.div`

--- a/src/pages/ShopSettingPage/index.tsx
+++ b/src/pages/ShopSettingPage/index.tsx
@@ -1,4 +1,5 @@
 import type { TabItem } from 'components/Tabs.tsx';
+import { useTab } from 'common/hooks/useTab';
 import { Button } from 'components/Button';
 import { Tabs } from 'components/Tabs.tsx';
 import { BusinessHourTab } from 'pages/ShopSettingPage/components/BusinessHourTab';
@@ -25,12 +26,19 @@ const tabList: TabItem[] = [
  * 가게 설정 페이지
  */
 export const ShopSettingPage: React.FC = () => {
+  const { activeTab, changeTab } = useTab();
+
   return (
     <Wrap>
       <SettingSideBar />
       <ContentWrap>
         <HeaderWrap>
-          <Tabs tabList={tabList} tabWidth='63rem' />
+          <Tabs
+            tabList={tabList}
+            tabWidth='63rem'
+            activeTab={activeTab}
+            onClickTab={changeTab}
+          />
           <Button
             width='7.6rem'
             height='3.6rem'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-resizable@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-resizable/-/react-resizable-3.0.4.tgz#2f5a1b6c79dd0b8729959deefc8628ab484724cc"
+  integrity sha512-+QguN9CDfC1lthq+4noG1fkxh8cqkV2Fv/Mu3mdknCCBiwwNLecnBdk1MmNNN7uJpT23Nx/aVkYsbt5NuWouFw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.0":
   version "18.2.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.8.tgz#a77dcffe4e9af148ca4aa8000c51a1e8ed99e2c8"
@@ -7980,10 +7987,6 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-hook-form@^7.45.0-next.1:
-  version "7.45.0-next.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.0-next.1.tgz#ec9ca4ade908e80d8a8430707d4ce12af0f55ad6"
-  integrity sha512-ksvvJm6c+rBl6XbXGj4GJhL073DRkIsDv0fvunaueeIC2ydp9YKozt8ofNEPimQ9XU3HOI+wuQBkXtYmVJCEpQ==
 react-grid-layout@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.3.4.tgz#4fa819be24a1ba9268aa11b82d63afc4762a32ff"
@@ -7994,6 +7997,11 @@ react-grid-layout@^1.3.4:
     prop-types "^15.8.1"
     react-draggable "^4.0.0"
     react-resizable "^3.0.4"
+
+react-hook-form@^7.45.0-next.1:
+  version "7.45.0-next.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.0-next.1.tgz#ec9ca4ade908e80d8a8430707d4ce12af0f55ad6"
+  integrity sha512-ksvvJm6c+rBl6XbXGj4GJhL073DRkIsDv0fvunaueeIC2ydp9YKozt8ofNEPimQ9XU3HOI+wuQBkXtYmVJCEpQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## 기획 및 구현한 내용

'좌석 설정 > 가게 형태' 탭에서 높이 조절 기능 구현 했습니다

요 브랜치 머지되면 퍼블리싱 세부 조정(이전 PR) 마저 작업하겠습니다
<!-- 구현한 기능에 관련된 기획을 서술 -->

## 변경사항

- `Tabs.tsx` 수정: 탭 전환 로직을 Tabs 밖으로 분리
  - 이유: 기존엔 탭 클릭 시에 탭 전환하면 됐는데 '가게 형태' 탭에선 탭 클릭 막아놓고 다른 버튼으로 탭을 전환시켜야 하기 때문
  -> `Tabs` 컴포넌트를 쓸 땐 `useTab` 훅과 함께 사용하면 됨

- `@types/react-resizable` 설치
  - 이유: 높이 조절할 때 `react-resizable` 라이브러리 씀
  - `react-resizable`은 원래도 깔려있던 라이브러리이나 (좌석 배치 기능 구현 시 사용), 높이 조절할 때 본격적으로 써야해서 type도 함께 설치함 
<!-- 주요 변경점 서술 -->

## 테스트 방법

`yarn install && yarn start`로 실행
`http://localhost:3000/layout` 접속

'가게형태' 탭에서 4가지 방식으로 높이 조절 해봄
1. 라디오 버튼 클릭
2. 가게 세로 길이 인풋창에 높이 입력
3. 가게 세로 길이 버튼 클릭
4. 마우스 드래그해서 높이 조절

높이 조절 후 '다음' 버튼 눌러서 '좌석 배치' 탭으로 이동 후 아이템들 드래그앤드롭 시킴
다시 '이전으로' 버튼 눌러서 '가게 형태' 탭으로 이동

아이템이 배치된 영역을 넘어서서 높이 조절이 불가능한지 확인

높이 조절 시 버그 존재하는 지 위주로 확인해주세요!

<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)
![높이조절](https://github.com/seat-checking/web-admin/assets/80534651/9897eb8c-fd82-4e52-b093-dcced5ea71d1)


<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [ ] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [x] 이슈 상태를 업데이트 함.
