### PR TITLE
[Feature/#6] 좌석 설정에서 사용되는 모달들 퍼블리싱

### DIFF
--- a/src/assets/icons/x.svg
+++ b/src/assets/icons/x.svg
@@ -1,4 +1,4 @@
 <svg width="2.4rem" height="2.4rem" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 6L6 18" stroke="#505462" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6 6L18 18" stroke="#505462" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 6L6 18" stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/Button.styled.ts
+++ b/src/components/Button.styled.ts
@@ -7,6 +7,7 @@ export const StyledButton = styled.button<{
   borderRadius: string;
   bgColor: string;
   color: string;
+  fontSize: string;
 }>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
@@ -16,8 +17,7 @@ export const StyledButton = styled.button<{
   border-radius: ${({ borderRadius }) => borderRadius};
 
   font-weight: 500;
-  font-size: 2rem;
-
+  font-size: ${({ fontSize }) => fontSize};
   &:hover {
     filter: brightness(95%);
   }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps extends React.HtmlHTMLAttributes<HTMLButtonElement> {
   type?: 'submit' | 'button' | 'reset' | undefined;
   backgroundColor?: string;
   color?: string;
+  fontSize?: string;
 }
 
 /**
@@ -26,6 +27,7 @@ export const Button: React.FC<ButtonProps> = ({
   children,
   backgroundColor,
   color = 'white',
+  fontSize = '2rem',
   ...rest
 }) => {
   const theme = useTheme();
@@ -40,6 +42,7 @@ export const Button: React.FC<ButtonProps> = ({
       borderRadius={borderRadius}
       bgColor={bgColor}
       color={color}
+      fontSize={fontSize}
       {...rest}
     >
       {children}

--- a/src/components/InputCheckBox.styled.ts
+++ b/src/components/InputCheckBox.styled.ts
@@ -1,27 +1,30 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import checkBoxImg from 'assets/icons/checkbox.svg';
 import checkedBoxImg from 'assets/icons/checkedbox.svg';
 
 export const InputCheckBoxWrapper = styled.div`
   max-width: 67.5rem;
+  height: 2.4rem;
 `;
 
 export const Input = styled.input`
-appearance: none;
-border: 0.15rem solid gainsboro;
-border-radius: 3.2rem;
-width: 2.4rem;
-height: 2.4rem;
-cursor: pointer;
-background-image: url(${checkBoxImg});
-background-size: 100% 100%;
-background-position: 50%;
-background-repeat: no-repeat;
-
-&:checked {
-  border-color: transparent;
-  background-image: url(${checkedBoxImg});
+  appearance: none;
+  border: 0.15rem solid gainsboro;
+  border-radius: 3.2rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  cursor: pointer;
+  background-image: url(${checkBoxImg});
   background-size: 100% 100%;
   background-position: 50%;
   background-repeat: no-repeat;
-  background-color: #ff8d4e;`;
+
+  &:checked {
+    border-color: transparent;
+    background-image: url(${checkedBoxImg});
+    background-size: 100% 100%;
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-color: #ff8d4e;
+  }
+`;

--- a/src/components/Modal.styled.ts
+++ b/src/components/Modal.styled.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const ModalWrapper = styled.div`
   width: 35.4rem;
-  height: 21.7rem;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -22,4 +21,6 @@ export const ModalOverlay = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  z-index: 100;
 `;

--- a/src/components/Modal.styled.ts
+++ b/src/components/Modal.styled.ts
@@ -24,3 +24,16 @@ export const ModalOverlay = styled.div`
 
   z-index: 100;
 `;
+
+export const HeaderWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  padding: 1.2rem 1.6rem;
+
+  color: ${({ theme }) => theme.palette.grey[500]};
+  font-size: 1.6rem;
+  font-weight: 700;
+
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[50]};
+`;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,13 +1,22 @@
-import type React from 'react';
-import { ModalOverlay, ModalWrapper } from 'components/Modal.styled';
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { ReactComponent as XIcon } from 'assets/icons/x.svg';
+import {
+  HeaderWrap,
+  ModalOverlay,
+  ModalWrapper,
+} from 'components/Modal.styled';
 
 interface ModalProps {
   isOpen: boolean;
+  closeOnOusideClick?: boolean;
   onClose?: () => void;
   children: React.ReactNode;
 }
 
-export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+export const Modal: React.FC<ModalProps> & {
+  Header: React.FC<HeaderProps>;
+} = ({ isOpen, onClose, children, closeOnOusideClick = true }) => {
   if (!isOpen) {
     return null;
   }
@@ -17,8 +26,42 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
   };
 
   return (
-    <ModalOverlay onClick={onClose}>
-      <ModalWrapper onClick={handleWrapperClick}>{children}</ModalWrapper>
+    <ModalOverlay {...(closeOnOusideClick && { onClick: onClose })}>
+      <ModalWrapper onClick={handleWrapperClick}>
+        {React.Children.map(children, (child) => {
+          if (
+            React.isValidElement<HeaderProps>(child) &&
+            child.type === Modal.Header
+          ) {
+            return React.cloneElement(child, { onClose });
+          }
+          return child;
+        })}
+      </ModalWrapper>
     </ModalOverlay>
   );
 };
+
+interface HeaderProps {
+  children: React.ReactNode;
+  onClose?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ children, onClose }) => {
+  const theme = useTheme();
+
+  const handleClose = () => {
+    onClose?.();
+  };
+
+  return (
+    <HeaderWrap>
+      {children}
+      <button type='button' onClick={handleClose}>
+        <XIcon stroke={theme.palette.grey[300]} />
+      </button>
+    </HeaderWrap>
+  );
+};
+
+Modal.Header = Header;

--- a/src/pages/LayoutSettingPage/components/AddSpaceModal.tsx
+++ b/src/pages/LayoutSettingPage/components/AddSpaceModal.tsx
@@ -44,13 +44,8 @@ export const AddSpaceModal: React.FC = () => {
   };
 
   return (
-    <Modal isOpen={isOpen}>
-      <Header>
-        스페이스 생성
-        <button type='button' onClick={handleClose}>
-          <XIcon stroke={theme.palette.grey[300]} />
-        </button>
-      </Header>
+    <Modal isOpen={isOpen} onClose={handleClose} closeOnOusideClick={false}>
+      <Modal.Header>스페이스 생성</Modal.Header>
       <Content>
         <SpaceNameLabel>사용할 스페이스의 이름을 적어주세요</SpaceNameLabel>
         <SpaceNameInput
@@ -95,19 +90,6 @@ export const AddSpaceModal: React.FC = () => {
     </Modal>
   );
 };
-
-const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-
-  padding: 1.2rem 1.6rem;
-
-  color: ${({ theme }) => theme.palette.grey[500]};
-  font-size: 1.6rem;
-  font-weight: 700;
-
-  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[50]};
-`;
 
 const Content = styled.div`
   padding: 1.6rem;

--- a/src/pages/LayoutSettingPage/components/AddSpaceModal.tsx
+++ b/src/pages/LayoutSettingPage/components/AddSpaceModal.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import styled, { useTheme } from 'styled-components/macro';
+import { ReactComponent as XIcon } from 'assets/icons/x.svg';
+import { Button } from 'components/Button';
+import InputCheckBox from 'components/InputCheckBox';
+import { Modal } from 'components/Modal';
+
+/**
+ * 스페이스 추가 모달
+ */
+export const AddSpaceModal: React.FC = () => {
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(true);
+  const [input, setInput] = useState('');
+  const [reservationUnits, setReservationUnits] = useState({
+    seat: true,
+    space: false,
+  });
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.currentTarget.value);
+  };
+
+  const handleChangeUnit = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const unit = e.currentTarget.name;
+    setReservationUnits({
+      ...reservationUnits,
+      [unit]: e.currentTarget.checked,
+    });
+  };
+
+  const getReservationHelperText = () => {
+    if (reservationUnits.seat && !reservationUnits.space)
+      return '고객이 좌석만 예약할 수 있어요';
+    if (!reservationUnits.seat && reservationUnits.space)
+      return '고객이 스페이스만 예약할 수 있어요';
+    if (reservationUnits.seat && reservationUnits.space)
+      return '고객이 좌석과 스페이스 모두 예약할 수 있어요';
+    return '예약 단위를 선택하셔야 돼요';
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen}>
+      <Header>
+        스페이스 생성
+        <button type='button' onClick={handleClose}>
+          <XIcon stroke={theme.palette.grey[300]} />
+        </button>
+      </Header>
+      <Content>
+        <SpaceNameLabel>사용할 스페이스의 이름을 적어주세요</SpaceNameLabel>
+        <SpaceNameInput
+          type='text'
+          value={input}
+          onChange={handleInput}
+          placeholder='ex) 1층 Blue 룸'
+        />
+        <UnitLabel>예약 단위 설정</UnitLabel>
+        <UnitInputsWrap>
+          <InputLabel>
+            <InputCheckBox
+              name='seat'
+              checked={reservationUnits.seat}
+              onChange={handleChangeUnit}
+            />
+            <InputLabelText>좌석</InputLabelText>
+          </InputLabel>
+          <InputLabel>
+            <InputCheckBox
+              name='space'
+              checked={reservationUnits.space}
+              onChange={handleChangeUnit}
+            />
+            <InputLabelText>스페이스</InputLabelText>
+          </InputLabel>
+        </UnitInputsWrap>
+        <UnitHelper>{getReservationHelperText()}</UnitHelper>
+        <Button
+          height='4.5rem'
+          backgroundColor={theme.palette.grey[500]}
+          borderRadius='0.4rem'
+          fontSize='1.4rem'
+          isDisabled={
+            input.length === 0 ||
+            (!reservationUnits.seat && !reservationUnits.space)
+          }
+        >
+          스페이스 생성
+        </Button>
+      </Content>
+    </Modal>
+  );
+};
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  padding: 1.2rem 1.6rem;
+
+  color: ${({ theme }) => theme.palette.grey[500]};
+  font-size: 1.6rem;
+  font-weight: 700;
+
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[50]};
+`;
+
+const Content = styled.div`
+  padding: 1.6rem;
+`;
+const SpaceNameLabel = styled.div`
+  margin-bottom: 1.6rem;
+  color: ${({ theme }) => theme.palette.black};
+  font-size: 1.8rem;
+  font-weight: 600;
+`;
+
+const SpaceNameInput = styled.input`
+  width: 100%;
+  padding: 1.2rem 1.6rem;
+
+  border-radius: 0.8rem;
+  border: 1px solid ${({ theme }) => theme.palette.grey[300]};
+
+  font-size: 1.6rem;
+  font-weight: 600;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.palette.grey[300]};
+  }
+`;
+
+const UnitLabel = styled.div`
+  margin-top: 2.4rem;
+
+  font-size: 1.2rem;
+  font-weight: 400;
+  color: ${({ theme }) => theme.palette.grey[300]};
+`;
+
+const InputLabel = styled.label`
+  display: flex;
+  align-items: center;
+  height: fit-content;
+
+  cursor: pointer;
+`;
+
+const InputLabelText = styled.span`
+  margin-left: 0.8rem;
+
+  color: ${({ theme }) => theme.palette.black};
+  font-size: 1.4rem;
+  font-weight: 600;
+`;
+
+const UnitInputsWrap = styled.div`
+  display: flex;
+  gap: 4rem;
+
+  margin-top: 1.2rem;
+  margin-bottom: 2.4rem;
+`;
+
+const UnitHelper = styled.div`
+  margin-bottom: 2.4rem;
+  text-align: center;
+
+  color: ${({ theme }) => theme.palette.primary.orange};
+  font-size: 1.4rem;
+  font-weight: 500;
+  line-height: 2.3rem;
+`;

--- a/src/pages/LayoutSettingPage/components/DeleteSpaceModal.tsx
+++ b/src/pages/LayoutSettingPage/components/DeleteSpaceModal.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Button } from 'components/Button';
+import { Modal } from 'components/Modal';
+
+/**
+ * 스페이스 삭제 모달
+ */
+export const DeleteSpaceModal: React.FC = () => {
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <Modal.Header>좌석 설정</Modal.Header>
+      <Content>
+        <ConfirmText>정말 스페이스를 삭제할까요? 😥</ConfirmText>
+        <DescriptionText>
+          삭제하면 스페이스 내부 좌석도 모두 사라져요.
+        </DescriptionText>
+      </Content>
+      <Footer>
+        <Button
+          backgroundColor={theme.palette.grey[100]}
+          color={theme.palette.grey[500]}
+          borderRadius='0.4rem'
+          fontSize='1.4rem'
+          height='4.5rem'
+          onClick={handleCancel}
+        >
+          취소
+        </Button>
+        <Button
+          backgroundColor={theme.palette.grey[500]}
+          borderRadius='0.4rem'
+          fontSize='1.4rem'
+          height='4.5rem'
+        >
+          스페이스 삭제
+        </Button>
+      </Footer>
+    </Modal>
+  );
+};
+
+const ConfirmText = styled.div`
+  font-size: 1.8rem;
+  font-weight: 600;
+`;
+
+const DescriptionText = styled.div`
+  margin-top: 0.6rem;
+
+  color: ${({ theme }) => theme.palette.grey[300]};
+  font-weight: 400;
+`;
+const Content = styled.div`
+  text-align: center;
+  padding: 1.6rem;
+  padding-bottom: 2.4rem;
+`;
+
+const Footer = styled.footer`
+  display: flex;
+  gap: 2rem;
+
+  padding: 1.6rem;
+
+  & > * {
+    flex: 1;
+  }
+`;

--- a/src/pages/LayoutSettingPage/components/ExitConfirmModal.tsx
+++ b/src/pages/LayoutSettingPage/components/ExitConfirmModal.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Button } from 'components/Button';
+import { Modal } from 'components/Modal';
+
+/**
+ * 저장하지 않았을 때 뜨는 확인 모달
+ */
+export const ExitConfirmModal: React.FC = () => {
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <Modal.Header>좌석 설정</Modal.Header>
+      <Content>
+        <ConfirmText>
+          좌석을 저장하지 않고 <br />
+          현재 스페이스를 나가시나요? 😥
+        </ConfirmText>
+        <DescriptionText>
+          저장하지 않으면 좌석이 모두 초기화 돼요!
+        </DescriptionText>
+      </Content>
+      <Footer>
+        <Button
+          backgroundColor={theme.palette.grey[100]}
+          color={theme.palette.grey[500]}
+          borderRadius='0.4rem'
+          fontSize='1.4rem'
+          height='4.5rem'
+          onClick={handleCancel}
+        >
+          스페이스 나가기
+        </Button>
+        <Button
+          backgroundColor={theme.palette.grey[500]}
+          borderRadius='0.4rem'
+          fontSize='1.4rem'
+          height='4.5rem'
+        >
+          저장하기
+        </Button>
+      </Footer>
+    </Modal>
+  );
+};
+
+const ConfirmText = styled.div`
+  font-size: 1.8rem;
+  font-weight: 600;
+  line-height: 2.3rem;
+`;
+
+const DescriptionText = styled.div`
+  margin-top: 0.6rem;
+
+  color: ${({ theme }) => theme.palette.grey[300]};
+  font-weight: 400;
+`;
+const Content = styled.div`
+  text-align: center;
+  padding: 1.6rem;
+  padding-bottom: 2.4rem;
+`;
+
+const Footer = styled.footer`
+  display: flex;
+  gap: 2rem;
+
+  padding: 1.6rem;
+
+  & > * {
+    flex: 1;
+  }
+`;

--- a/src/pages/LayoutSettingPage/components/Space.tsx
+++ b/src/pages/LayoutSettingPage/components/Space.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import styled, { css } from 'styled-components/macro';
+import styled, { css, useTheme } from 'styled-components/macro';
 import type { ChangeEvent } from 'react';
 import { ReactComponent as XIcon } from 'assets/icons/x.svg';
 import { flexSet } from 'styles/mixin';
@@ -22,6 +22,7 @@ export const Space: React.FC<SpaceProps> = ({
   isSelected,
   deleteSpace,
 }) => {
+  const theme = useTheme();
   const [spaceName, setSpaceName] = useState(name);
 
   const handleChangeName = (event: ChangeEvent<HTMLInputElement>) => {
@@ -36,7 +37,7 @@ export const Space: React.FC<SpaceProps> = ({
     <SpaceBox onClick={() => onClick(id)} isSelected={isSelected}>
       <Input type='text' onChange={handleChangeName} value={spaceName} />
       <DeleteWrap onClick={handleDeleteSpace}>
-        <XIcon />
+        <XIcon stroke={theme.palette.grey[500]} />
       </DeleteWrap>
     </SpaceBox>
   );

--- a/src/pages/LayoutSettingPage/components/SpaceRow.tsx
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.tsx
@@ -1,5 +1,8 @@
 import { ReactComponent as AlertCircleBorderIcon } from 'assets/icons/alert-circle-border.svg';
 import { ReactComponent as PlusCircle } from 'assets/icons/plus-circle.svg';
+import { AddSpaceModal } from 'pages/LayoutSettingPage/components/AddSpaceModal';
+import { DeleteSpaceModal } from 'pages/LayoutSettingPage/components/DeleteSpaceModal';
+import { ExitConfirmModal } from 'pages/LayoutSettingPage/components/ExitConfirmModal';
 
 import { Space } from 'pages/LayoutSettingPage/components/Space';
 import {
@@ -40,6 +43,9 @@ export const SpaceRow: React.FC = () => {
           <AddText>스페이스 추가</AddText>
         </AddRow>
       </SpaceWrap>
+      <AddSpaceModal />
+      <DeleteSpaceModal />
+      <ExitConfirmModal />
     </>
   );
 };


### PR DESCRIPTION
## 기획 및 구현한 내용

세 개의 모달 퍼블리싱 했습니다

1. 좌석 설정 중 이탈 행동 경고 알럿
<img width="210" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/ee81f7f7-71d9-4829-b77b-908dfea7d844">

2. 스페이스 생성 모달
<img width="248" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/a0fe3ea5-1066-4709-a204-90e6005639c9">

3. 스페이스 삭제 모달
<img width="262" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/2619287b-a5a7-4e12-9206-1f94e6c5a4cb">

<!-- 구현한 기능에 관련된 기획을 서술 -->

## 변경사항

### Modal.tsx
1. 모든 모달에 헤더 영역(텍스트 + 삭제 버튼)이 있길래 Modal.tsx 안에 Header 컴포넌트를 추가했습니다
  <img width="464" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/5539cc95-3cf3-4c84-99fc-2bd08abf5dda">

  
사용 시엔 헤더에 띄울 텍스트만 children으로 넣으면 돼요
  <img width="493" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/23f215d9-80fe-41e6-b003-6a3f0e18d517">


2. `closeOnOusideClick` 프롭스 추가
- 외부 영역 클릭했을 때 모달 닫을지 말지에 대한 여부를 나타냄
- 디폴트는 true 여서 외부 클릭시 닫김
- 이유: Modal.Header엔 삭제 버튼이 있어서 onClose가 필수인데 onClose를 넣으면 모달 외부 클릭 시 삭제도 자동으로 설정 되기 때문에 추가했음




<!-- 주요 변경점 서술 -->

## 테스트 방법

`yarn start` 로 실행
`http://localhost:3000/layout`로 이동


모달 3개를 동시에 띄워놨어요.  (기능 구현 X)
x표 눌러서 제거하면서 하나씩 확인 하시면 돼요 
<img width="828" alt="image" src="https://github.com/seat-checking/web-admin/assets/80534651/1b1e3650-eef8-4e75-94a2-153bce0f6fb9">

<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)

<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [ ] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [ ] 이슈 상태를 업데이트 함.
