### PR TITLE
[Feature/#51] 전화번호 null 허용, 한줄소개 -> 소개 변경

### DIFF
--- a/src/api/shop/index.ts
+++ b/src/api/shop/index.ts
@@ -15,7 +15,6 @@ import type {
 } from 'common/utils/types';
 import type { SpaceType } from 'pages/LayoutSettingPage/utils/types';
 import { axiosClient } from 'api/apiClient';
-import { STORAGE } from 'common/utils/constants';
 
 export const addShop = async (shopInfoForm: ShopInfoForm) => {
   const response = await axiosClient.post(

--- a/src/common/hooks/mutations/useCreateSpace.ts
+++ b/src/common/hooks/mutations/useCreateSpace.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import type { ShopLayout } from 'api/shop/types';
 import { ShopApi } from 'api/shop';
 import { useSpaceId } from 'pages/LayoutSettingPage/hooks/useSpaceId';

--- a/src/common/hooks/mutations/useCreateSpace.ts
+++ b/src/common/hooks/mutations/useCreateSpace.ts
@@ -1,12 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { ShopLayout } from 'api/shop/types';
 import { ShopApi } from 'api/shop';
-import { queryKeys } from 'common/utils/constants';
 import { useSpaceId } from 'pages/LayoutSettingPage/hooks/useSpaceId';
 import { useChange } from 'pages/LayoutSettingPage/stores/changeStore';
 
 export const useCreateSpace = () => {
-  const queryClient = useQueryClient();
   const { setSpaceId } = useSpaceId();
   const { setChange } = useChange();
 
@@ -20,10 +18,7 @@ export const useCreateSpace = () => {
     }) => {
       return ShopApi.createShopLayout(shopId, layout);
     },
-    onSuccess(createdSpaceId, { shopId }) {
-      queryClient.invalidateQueries({
-        queryKey: [queryKeys.GET_SPACES, shopId],
-      });
+    onSuccess(createdSpaceId) {
       setSpaceId(createdSpaceId);
       setChange(false);
     },

--- a/src/common/hooks/mutations/useEditLayout.ts
+++ b/src/common/hooks/mutations/useEditLayout.ts
@@ -2,18 +2,22 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { EditShopLayoutRequest } from 'api/shop/types';
 import { ShopApi } from 'api/shop';
 import { queryKeys } from 'common/utils/constants';
+import { useChange } from 'pages/LayoutSettingPage/stores/changeStore';
 
 export const useEditLayout = () => {
   const queryClient = useQueryClient();
+  const { setChange } = useChange();
 
   return useMutation({
     mutationFn: ({ spaceId, layout }: EditShopLayoutRequest) => {
       return ShopApi.editShopLayout({ spaceId, layout });
     },
-    onSuccess(_, { spaceId }) {
-      queryClient.invalidateQueries({
-        queryKey: [queryKeys.GET_SPACE_LAYOUT, spaceId],
+    onSuccess(_, { spaceId, layout }) {
+      queryClient.setQueryData([queryKeys.GET_SPACE_LAYOUT, spaceId], {
+        storeSpaceId: spaceId,
+        ...layout,
       });
+      setChange(false);
     },
   });
 };

--- a/src/common/hooks/mutations/useEditShopInformation.ts
+++ b/src/common/hooks/mutations/useEditShopInformation.ts
@@ -1,18 +1,22 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import type { ShopInformationForm } from 'common/utils/types';
+import type { EditShopInformationRequest } from 'api/shop/types';
 import { editShopInformation } from 'api/shop';
-import { useSelectedShop } from 'common/stores/authStore';
+import { queryKeys } from 'common/utils/constants';
 
 export const useEditShopInformation = () => {
-  const { storeId: shopId } = useSelectedShop();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (params: ShopInformationForm) => {
-      return editShopInformation({ ...params, shopId });
+    mutationFn: (params: EditShopInformationRequest) => {
+      return editShopInformation({ ...params });
     },
-    onSuccess: () => {
+    onSuccess: (_, { shopId: usedShopId }) => {
       toast.success('변경사항이 성공적으로 저장되었습니다.');
+      queryClient.invalidateQueries([
+        queryKeys.GET_SHOP_INFORMATION,
+        usedShopId,
+      ]);
     },
   });
 };

--- a/src/pages/LayoutSettingPage/components/ExitConfirmModal.tsx
+++ b/src/pages/LayoutSettingPage/components/ExitConfirmModal.tsx
@@ -1,7 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query';
 import styled, { useTheme } from 'styled-components';
-import { useSelectedShop } from 'common/stores/authStore';
-import { queryKeys } from 'common/utils/constants';
 import { Button } from 'components/Button';
 import { Modal } from 'components/Modal';
 import { useSaveLayout } from 'pages/LayoutSettingPage/hooks/useSaveLayout';
@@ -24,24 +21,16 @@ export const ExitConfirmModal: React.FC<ExitConfirmModalProps> = ({
   const { setChange } = useChange();
   const saveLayout = useSaveLayout();
 
-  const queryClient = useQueryClient();
-  const { storeId: shopId } = useSelectedShop();
-
   const handleCancel = () => {
     setChange(false);
     clearSpaces();
     onComplete?.();
-
     onClose();
   };
 
   const handleSave = () => {
-    setChange(false);
-    queryClient.invalidateQueries([queryKeys.GET_SPACES, shopId]);
     onComplete?.();
-
     saveLayout();
-
     onClose();
   };
 

--- a/src/pages/LayoutSettingPage/components/SpaceRow.tsx
+++ b/src/pages/LayoutSettingPage/components/SpaceRow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ReactComponent as AlertCircleBorderIcon } from 'assets/icons/alert-circle-border.svg';
 import { ReactComponent as PlusCircle } from 'assets/icons/plus-circle.svg';
 
+import { useSelectedShop } from 'common/stores/authStore';
 import { ExitConfirmModal } from 'pages/LayoutSettingPage/components/ExitConfirmModal';
 import { Space } from 'pages/LayoutSettingPage/components/Space';
 import { SpaceAddEditModal } from 'pages/LayoutSettingPage/components/SpaceAddEditModal';
@@ -25,6 +26,7 @@ import { useModal } from 'pages/LayoutSettingPage/stores/modalStore';
  * space 목록 컴포넌트 (검은색 영역)
  */
 export const SpaceRow: React.FC = () => {
+  const { storeId: shopId } = useSelectedShop();
   const { setSpaceId, spaceId, setFirstSpaceId } = useSpaceId();
   const { isChanged } = useChange();
   const { setIsAddOn, isAddOn } = useModal();
@@ -77,6 +79,10 @@ export const SpaceRow: React.FC = () => {
       setIsAddOn(true);
     }
   }, [spaceList, setFirstSpaceId, setIsAddOn]);
+
+  useEffect(() => {
+    firstLoadedRef.current = false;
+  }, [shopId]);
 
   return (
     <>

--- a/src/pages/LayoutSettingPage/hooks/useSaveLayout.ts
+++ b/src/pages/LayoutSettingPage/hooks/useSaveLayout.ts
@@ -1,9 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import type { ReservationUnit, ShopLayout } from 'api/shop/types';
 import type { CustomItemLayout } from 'pages/LayoutSettingPage/utils/types';
 import { useCreateSpace } from 'common/hooks/mutations/useCreateSpace';
 import { useEditLayout } from 'common/hooks/mutations/useEditLayout';
 import { useSelectedShop } from 'common/stores/authStore';
-import { TEMPORARY_SPACE_ID } from 'common/utils/constants';
+import { TEMPORARY_SPACE_ID, queryKeys } from 'common/utils/constants';
 import { useSpaceId } from 'pages/LayoutSettingPage/hooks/useSpaceId';
 import { useChange } from 'pages/LayoutSettingPage/stores/changeStore';
 import { useLayout } from 'pages/LayoutSettingPage/stores/layoutStore';
@@ -50,6 +51,7 @@ export const convertDataForServer = (
 export const useSaveLayout = () => {
   const height = useShopHeight();
   const layout = useLayout();
+  const queryClient = useQueryClient();
   const { setChange } = useChange();
 
   const { mutate: editLayoutMutate } = useEditLayout();
@@ -62,6 +64,7 @@ export const useSaveLayout = () => {
 
   const handleSave = () => {
     if (!shopId) return;
+    queryClient.invalidateQueries([queryKeys.GET_SPACES, shopId]);
     if (spaceId === TEMPORARY_SPACE_ID) {
       createSpaceMutate({
         layout: convertDataForServer(

--- a/src/pages/LayoutSettingPage/hooks/useSaveLayout.ts
+++ b/src/pages/LayoutSettingPage/hooks/useSaveLayout.ts
@@ -52,7 +52,6 @@ export const useSaveLayout = () => {
   const height = useShopHeight();
   const layout = useLayout();
   const queryClient = useQueryClient();
-  const { setChange } = useChange();
 
   const { mutate: editLayoutMutate } = useEditLayout();
   const { mutate: createSpaceMutate } = useCreateSpace();
@@ -81,7 +80,6 @@ export const useSaveLayout = () => {
       spaceId,
       layout: convertDataForServer(layout, height, spaceName, reservationUnit),
     });
-    setChange(false);
   };
 
   return handleSave;

--- a/src/pages/LayoutSettingPage/stores/layoutStore.ts
+++ b/src/pages/LayoutSettingPage/stores/layoutStore.ts
@@ -77,10 +77,11 @@ const useLayoutStore = create<LayoutStoreState>()(
             const newLayout = state.layout.map((prevItem, idx) => {
               return {
                 ...prevItem,
-                w: changedLayout[idx].w,
-                h: changedLayout[idx].h,
-                x: changedLayout[idx].x,
-                y: changedLayout[idx].y,
+                // FIXME w가 왜 비어있는지 파악해야함
+                w: changedLayout[idx]?.w,
+                h: changedLayout[idx]?.h,
+                x: changedLayout[idx]?.x,
+                y: changedLayout[idx]?.y,
               };
             });
             return {

--- a/src/pages/LayoutSettingPage/stores/layoutStore.ts
+++ b/src/pages/LayoutSettingPage/stores/layoutStore.ts
@@ -100,6 +100,8 @@ const useLayoutStore = create<LayoutStoreState>()(
                 break;
               }
             }
+            useChangeStore.getState().setChange(true);
+
             return { layout: copy };
           },
           false,

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro';
 import upload from 'assets/icons/upload.svg';
 import { Button } from 'components/Button';
 import { ErrorMessage } from 'components/ErrorMessage';
+import { StyledInput } from 'components/Input.styled';
 
 export const ContentWrap = styled.ul`
   width: 100%;
@@ -69,4 +70,17 @@ export const RadioRow = styled.div`
   gap: 8.7rem;
 
   padding-top: 0.8rem;
+`;
+
+export const TextArea = styled(StyledInput).attrs({ as: 'textarea' })`
+  padding: 1rem 1.6rem;
+
+  width: 100%;
+  height: 8rem;
+  border: 0.1rem solid ${({ theme }) => theme.palette.grey[300]};
+  border-radius: 0.8rem;
+
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 2.4rem;
 `;

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTheme } from 'styled-components';
 import type { ShopInformationForm } from 'common/utils/types';
@@ -52,6 +52,7 @@ export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
     register,
     handleSubmit,
     formState: { errors },
+    reset,
     setError,
     control,
   } = useForm<ShopInformationForm>({
@@ -100,6 +101,10 @@ export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
   const onSubmit: SubmitHandler<ShopInformationForm> = (data) => {
     editShopSettingMutate({ ...data, shopId });
   };
+
+  useEffect(() => {
+    reset(shopInformation);
+  }, [reset, shopInformation]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
@@ -23,6 +23,7 @@ import {
   AddFileRow,
   UploadIconBox,
   GappedErrorMessage,
+  TextArea,
 } from 'pages/ShopSettingPage/components/ShopInfoTab/ShopInfoTab.styled';
 
 import { Carousel } from 'pages/ShopSettingPage/components/ShopInfoTab/components/Carousel';
@@ -233,12 +234,11 @@ export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
           )}
         </ListItem>
         <ListItem>
-          <Input
-            label='한 줄 소개'
-            maxLength={30}
-            placeholder='가게의 소개글을 작성해주세요. (최대 30자 이내)'
+          <Label label='가게 소개' />
+          <TextArea
+            placeholder='가게의 소개글을 작성해주세요.'
             {...register('introduction', {
-              required: '한 줄 소개는 필수 입력입니다.',
+              required: '소개 문구는 필수 입력입니다.',
             })}
           />
           {errors.introduction && (

--- a/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
+++ b/src/pages/ShopSettingPage/components/ShopInfoTab/index.tsx
@@ -8,6 +8,7 @@ import type { SubmitHandler } from 'react-hook-form';
 
 import { useEditShopInformation } from 'common/hooks/mutations/useEditShopInformation';
 import { useAddress } from 'common/hooks/useAddress';
+import { useSelectedShop } from 'common/stores/authStore';
 import { AddressBox } from 'components/AddressBox';
 import { Button } from 'components/Button';
 import { Input } from 'components/Input';
@@ -41,6 +42,8 @@ interface ShopInfoTabProps {
 export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
   shopInformation,
 }) => {
+  const { storeId: shopId } = useSelectedShop();
+
   const theme = useTheme();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -94,7 +97,7 @@ export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
   };
 
   const onSubmit: SubmitHandler<ShopInformationForm> = (data) => {
-    editShopSettingMutate({ ...data });
+    editShopSettingMutate({ ...data, shopId });
   };
 
   return (
@@ -150,11 +153,10 @@ export const ShopInfoTab: React.FC<ShopInfoTabProps> = ({
         </ListItem>
         <ListItem>
           <Input
+            required={false}
             label='가게 전화번호'
             placeholder='(ex. 010-1234-5678)'
-            {...register('telNum', {
-              required: '가게 전화번호는 필수 입력입니다.',
-            })}
+            {...register('telNum')}
           />
           {errors.telNum && (
             <GappedErrorMessage>{errors.telNum?.message}</GappedErrorMessage>


### PR DESCRIPTION
## 기획 및 구현한 내용

테스트 하다 발견한 버그들 고치고 기획 변경 사항 반영했습니다

[가게 정보 설정]  
1. 전화번호 필수값이 아닌 옵션으로  변경
2. 한줄소개 -> 소개로 변경, 글자 수 제한 없앰
3. GNB에서 선택된 가게 바꿨을 때 불러온 데이터 안바뀌는 문제 해결

[좌석 설정]
1. 의자 번호 수정했을 때도 저장 버튼 활성화 되도록 함
2. GNB에서 선택된 가게 바꿨을 때 불러온 데이터 안바뀌는 문제 해결

<!-- 구현한 기능에 관련된 기획을 서술 -->

## 테스트 방법
1. yarn start로 실행
2. 가게 정보 설정 & 좌석 설정 페이지 들어가서 확인

<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [x] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [x] 이슈 상태를 업데이트 함.
